### PR TITLE
feat: 桜県の包括的な雇用施設データを追加

### DIFF
--- a/sakura-ken/data/education-facilities.json
+++ b/sakura-ken/data/education-facilities.json
@@ -1,0 +1,558 @@
+{
+  "universities": [
+    {
+      "id": "UN001",
+      "name": "桜花大学",
+      "type": "国立大学",
+      "category": "総合大学",
+      "location": {
+        "city": "桜花市",
+        "district": "大学町",
+        "address": "桜花市大学町1-1",
+        "coordinates": {"lat": 35.7250, "lng": 139.8700},
+        "campus_area_m2": 450000
+      },
+      "facility_info": {
+        "established": "1920-04-01",
+        "campuses": 3,
+        "buildings": 45,
+        "libraries": 5,
+        "research_centers": 12,
+        "dormitories": 8,
+        "sports_facilities": 15
+      },
+      "faculties": [
+        "法学部", "経済学部", "文学部", "理学部", "工学部", "医学部",
+        "薬学部", "農学部", "教育学部", "情報科学部"
+      ],
+      "students": {
+        "undergraduate": 15000,
+        "graduate": 3500,
+        "doctoral": 800,
+        "international": 1200
+      },
+      "employees": {
+        "total": 3456,
+        "professors": 456,
+        "associate_professors": 567,
+        "assistant_professors": 678,
+        "lecturers": 345,
+        "administrative": 1234,
+        "technical": 176,
+        "management": [
+          {
+            "employee_id": "UN001-M001",
+            "name": "学長田教育",
+            "position": "学長",
+            "department": "大学本部",
+            "specialization": "教育学",
+            "hire_date": "2020-04-01",
+            "annual_salary": 20000000
+          },
+          {
+            "employee_id": "UN001-M002",
+            "name": "副学長田研究",
+            "position": "副学長（研究担当）",
+            "department": "研究推進部",
+            "specialization": "物理学",
+            "hire_date": "2019-04-01",
+            "annual_salary": 15000000
+          }
+        ],
+        "sample_faculty": [
+          {
+            "employee_id": "UN001-F001",
+            "name": "教授田法律",
+            "position": "教授",
+            "department": "法学部",
+            "specialization": "憲法学",
+            "hire_date": "2005-04-01",
+            "annual_salary": 12000000
+          },
+          {
+            "employee_id": "UN001-F002",
+            "name": "准教授田経済",
+            "position": "准教授",
+            "department": "経済学部",
+            "specialization": "マクロ経済学",
+            "hire_date": "2012-04-01",
+            "annual_salary": 8000000
+          }
+        ]
+      },
+      "research": {
+        "annual_budget_million_yen": 8500,
+        "patents_annually": 234,
+        "international_collaborations": 156
+      }
+    },
+    {
+      "id": "UN002",
+      "name": "桜川工科大学",
+      "type": "公立大学",
+      "category": "工科大学",
+      "location": {
+        "city": "桜川市",
+        "district": "学園都市",
+        "address": "桜川市学園都市2-3-4",
+        "coordinates": {"lat": 35.6900, "lng": 139.9200},
+        "campus_area_m2": 280000
+      },
+      "facility_info": {
+        "established": "1965-04-01",
+        "buildings": 25,
+        "laboratories": 80,
+        "clean_rooms": 12
+      },
+      "faculties": [
+        "機械工学科", "電気電子工学科", "情報工学科", "建築学科", "環境工学科"
+      ],
+      "students": {
+        "undergraduate": 8000,
+        "graduate": 2000,
+        "doctoral": 400
+      },
+      "employees": {
+        "total": 1234,
+        "professors": 156,
+        "associate_professors": 234,
+        "assistant_professors": 289,
+        "administrative": 456,
+        "technical": 99
+      }
+    },
+    {
+      "id": "UN003",
+      "name": "桜花女子大学",
+      "type": "私立大学",
+      "category": "女子大学",
+      "location": {
+        "city": "桜花市",
+        "district": "文教地区",
+        "address": "桜花市文教地区5-6-7"
+      },
+      "faculties": [
+        "文学部", "家政学部", "看護学部", "国際教養学部"
+      ],
+      "students": {
+        "undergraduate": 4500,
+        "graduate": 500
+      },
+      "employees": {
+        "total": 567,
+        "faculty": 234,
+        "administrative": 333
+      }
+    }
+  ],
+  "vocational_schools": [
+    {
+      "id": "VS001",
+      "name": "桜県立職業能力開発大学校",
+      "type": "職業能力開発大学校",
+      "location": {
+        "city": "桜花市",
+        "district": "産業地区",
+        "address": "桜花市産業地区職業訓練通り1-1"
+      },
+      "courses": [
+        "機械システム工学科", "電気エネルギー制御科", "電子情報技術科", "建築科"
+      ],
+      "students": 1200,
+      "employees": {
+        "total": 156,
+        "instructors": 89,
+        "administrative": 67
+      }
+    },
+    {
+      "id": "VS002",
+      "name": "桜花医療専門学校",
+      "type": "専門学校",
+      "specialization": "医療系",
+      "location": {
+        "city": "桜花市",
+        "district": "医療地区",
+        "address": "桜花市医療地区専門学校通り2-3"
+      },
+      "courses": [
+        "看護学科", "理学療法学科", "作業療法学科", "臨床検査学科"
+      ],
+      "students": 800,
+      "employees": {
+        "total": 89,
+        "instructors": 56,
+        "administrative": 33
+      }
+    }
+  ],
+  "high_schools": [
+    {
+      "id": "HS001",
+      "name": "桜県立桜花高等学校",
+      "type": "公立高等学校",
+      "category": "進学校",
+      "location": {
+        "city": "桜花市",
+        "district": "文教地区",
+        "address": "桜花市文教地区学園通り1-1-1"
+      },
+      "facility_info": {
+        "established": "1901-04-01",
+        "buildings": 5,
+        "classrooms": 45,
+        "laboratories": 12,
+        "gymnasium": 2,
+        "sports_grounds": 3
+      },
+      "students": {
+        "total": 1200,
+        "first_year": 400,
+        "second_year": 400,
+        "third_year": 400
+      },
+      "employees": {
+        "total": 98,
+        "teachers": 67,
+        "administrative": 21,
+        "support_staff": 10,
+        "management": [
+          {
+            "employee_id": "HS001-M001",
+            "name": "校長田教育",
+            "position": "校長",
+            "subject": "数学",
+            "hire_date": "2018-04-01",
+            "annual_salary": 8500000
+          },
+          {
+            "employee_id": "HS001-M002",
+            "name": "教頭田指導",
+            "position": "教頭",
+            "subject": "英語",
+            "hire_date": "2020-04-01",
+            "annual_salary": 7500000
+          }
+        ]
+      },
+      "academic_performance": {
+        "university_advancement_rate": 0.95,
+        "national_university_rate": 0.45
+      }
+    },
+    {
+      "id": "HS002",
+      "name": "桜川市立第一高等学校",
+      "type": "公立高等学校",
+      "category": "総合高校",
+      "location": {
+        "city": "桜川市",
+        "district": "教育地区",
+        "address": "桜川市教育地区高校通り2-3-4"
+      },
+      "students": 900,
+      "employees": {
+        "total": 78,
+        "teachers": 56,
+        "administrative": 22
+      }
+    },
+    {
+      "id": "HS003",
+      "name": "私立桜花学園高等学校",
+      "type": "私立高等学校",
+      "category": "中高一貫校",
+      "location": {
+        "city": "桜花市",
+        "district": "南区",
+        "address": "桜花市南区私学の森3-4-5"
+      },
+      "students": 1800,
+      "employees": {
+        "total": 145,
+        "teachers": 105,
+        "administrative": 40
+      }
+    }
+  ],
+  "junior_high_schools": [
+    {
+      "id": "JH001",
+      "name": "桜花市立第一中学校",
+      "type": "公立中学校",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区中学校通り1-1"
+      },
+      "students": 600,
+      "employees": {
+        "total": 45,
+        "teachers": 34,
+        "administrative": 11
+      }
+    },
+    {
+      "id": "JH002",
+      "name": "桜花市立第二中学校",
+      "type": "公立中学校",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区学校通り2-2"
+      },
+      "students": 550,
+      "employees": {
+        "total": 42,
+        "teachers": 32,
+        "administrative": 10
+      }
+    }
+  ],
+  "elementary_schools": [
+    {
+      "id": "ES001",
+      "name": "桜花市立中央小学校",
+      "type": "公立小学校",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区小学校通り1-1"
+      },
+      "facility_info": {
+        "classrooms": 24,
+        "special_rooms": 8,
+        "playground_area_m2": 5000
+      },
+      "students": 720,
+      "employees": {
+        "total": 38,
+        "teachers": 28,
+        "administrative": 6,
+        "support_staff": 4,
+        "management": [
+          {
+            "employee_id": "ES001-M001",
+            "name": "小学田校長",
+            "position": "校長",
+            "hire_date": "2019-04-01",
+            "annual_salary": 7000000
+          }
+        ]
+      }
+    },
+    {
+      "id": "ES002",
+      "name": "桜花市立東小学校",
+      "type": "公立小学校",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区桜通り2-2"
+      },
+      "students": 650,
+      "employees": {
+        "total": 35,
+        "teachers": 26,
+        "administrative": 9
+      }
+    },
+    {
+      "id": "ES003",
+      "name": "桜花市立西小学校",
+      "type": "公立小学校",
+      "location": {
+        "city": "桜花市",
+        "district": "西区",
+        "address": "桜花市西区学園通り3-3"
+      },
+      "students": 580,
+      "employees": {
+        "total": 32,
+        "teachers": 24,
+        "administrative": 8
+      }
+    }
+  ],
+  "kindergartens": [
+    {
+      "id": "KG001",
+      "name": "桜花市立中央幼稚園",
+      "type": "公立幼稚園",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区子供の森1-1"
+      },
+      "capacity": 180,
+      "employees": {
+        "total": 18,
+        "teachers": 12,
+        "support_staff": 6
+      }
+    },
+    {
+      "id": "KG002",
+      "name": "私立さくら幼稚園",
+      "type": "私立幼稚園",
+      "location": {
+        "city": "桜花市",
+        "district": "南区",
+        "address": "桜花市南区花園通り2-2"
+      },
+      "capacity": 200,
+      "employees": {
+        "total": 22,
+        "teachers": 15,
+        "support_staff": 7
+      }
+    }
+  ],
+  "nursery_schools": [
+    {
+      "id": "NS001",
+      "name": "桜花市立第一保育園",
+      "type": "公立保育園",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区保育園通り1-1"
+      },
+      "capacity": 120,
+      "age_groups": ["0歳児", "1歳児", "2歳児", "3歳児", "4歳児", "5歳児"],
+      "employees": {
+        "total": 28,
+        "nursery_teachers": 20,
+        "nutritionists": 2,
+        "nurses": 2,
+        "administrative": 4
+      }
+    }
+  ],
+  "cram_schools": [
+    {
+      "id": "CS001",
+      "name": "桜花進学塾",
+      "type": "学習塾",
+      "chain": "桜花教育グループ",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区教育ビル3F"
+      },
+      "courses": ["小学生", "中学生", "高校生", "大学受験"],
+      "students": 450,
+      "employees": {
+        "total": 34,
+        "instructors": 25,
+        "administrative": 9
+      }
+    }
+  ],
+  "language_schools": [
+    {
+      "id": "LS001",
+      "name": "桜花国際言語学院",
+      "type": "語学学校",
+      "specialization": "英語・中国語・韓国語",
+      "location": {
+        "city": "桜花市",
+        "district": "国際地区",
+        "address": "桜花市国際地区グローバル通り1-1"
+      },
+      "students": 800,
+      "employees": {
+        "total": 45,
+        "instructors": 32,
+        "native_speakers": 20,
+        "administrative": 13
+      }
+    }
+  ],
+  "training_centers": [
+    {
+      "id": "TC001",
+      "name": "桜県職業訓練センター",
+      "type": "職業訓練施設",
+      "location": {
+        "city": "桜花市",
+        "district": "産業地区",
+        "address": "桜花市産業地区スキルアップ通り1-1"
+      },
+      "courses": [
+        "IT基礎", "CAD/CAM", "電気工事", "介護職員初任者研修", "フォークリフト運転"
+      ],
+      "annual_trainees": 2400,
+      "employees": {
+        "total": 56,
+        "instructors": 38,
+        "administrative": 18
+      }
+    }
+  ],
+  "libraries": [
+    {
+      "id": "LB001",
+      "name": "桜県立中央図書館",
+      "type": "公立図書館",
+      "location": {
+        "city": "桜花市",
+        "district": "文化地区",
+        "address": "桜花市文化地区図書館通り1-1"
+      },
+      "facility_info": {
+        "floors": 5,
+        "collection_size": 1200000,
+        "reading_seats": 500,
+        "study_rooms": 20,
+        "computer_terminals": 100
+      },
+      "employees": {
+        "total": 78,
+        "librarians": 45,
+        "technical_staff": 12,
+        "administrative": 21,
+        "management": [
+          {
+            "employee_id": "LB001-M001",
+            "name": "図書田管理",
+            "position": "館長",
+            "specialization": "図書館情報学",
+            "hire_date": "2015-04-01",
+            "annual_salary": 8000000
+          }
+        ]
+      },
+      "annual_visitors": 850000
+    }
+  ],
+  "research_institutes": [
+    {
+      "id": "RI001",
+      "name": "桜県産業技術研究所",
+      "type": "研究機関",
+      "specialization": "工業技術・材料科学",
+      "location": {
+        "city": "桜花市",
+        "district": "研究開発地区",
+        "address": "桜花市研究開発地区イノベーション通り1-1"
+      },
+      "employees": {
+        "total": 234,
+        "researchers": 156,
+        "technicians": 45,
+        "administrative": 33
+      }
+    }
+  ],
+  "summary": {
+    "total_education_employees": 12456,
+    "universities": 8,
+    "high_schools": 45,
+    "junior_high_schools": 78,
+    "elementary_schools": 156,
+    "kindergartens_nurseries": 234,
+    "total_students": 380000,
+    "education_coverage": "充実した教育体制で全年齢層に対応"
+  }
+}

--- a/sakura-ken/data/financial-services.json
+++ b/sakura-ken/data/financial-services.json
@@ -1,0 +1,571 @@
+{
+  "major_banks": [
+    {
+      "id": "MB001",
+      "name": "桜花銀行本店",
+      "type": "地方銀行本店",
+      "bank_name": "桜花銀行",
+      "location": {
+        "city": "桜花市",
+        "district": "金融街",
+        "address": "桜花市金融街1-1-1",
+        "coordinates": {"lat": 35.7090, "lng": 139.8440},
+        "area_m2": 15000
+      },
+      "facility_info": {
+        "established": "1878-05-01",
+        "floors": 20,
+        "underground_floors": 3,
+        "atm_count": 25,
+        "meeting_rooms": 30,
+        "safe_deposit_boxes": 5000
+      },
+      "services": {
+        "retail_banking": true,
+        "corporate_banking": true,
+        "investment_banking": true,
+        "private_banking": true,
+        "foreign_exchange": true,
+        "loan_center": true
+      },
+      "employees": {
+        "total": 1234,
+        "bankers": 567,
+        "tellers": 234,
+        "loan_officers": 123,
+        "investment_advisors": 89,
+        "it_staff": 78,
+        "administrative": 143,
+        "management": [
+          {
+            "employee_id": "MB001-M001",
+            "name": "頭取田金融",
+            "position": "頭取",
+            "department": "経営企画部",
+            "hire_date": "2019-06-01",
+            "annual_salary": 35000000
+          },
+          {
+            "employee_id": "MB001-M002",
+            "name": "専務田経営",
+            "position": "専務取締役",
+            "department": "経営企画部",
+            "hire_date": "2020-06-01",
+            "annual_salary": 25000000
+          },
+          {
+            "employee_id": "MB001-M003",
+            "name": "常務田営業",
+            "position": "常務取締役",
+            "department": "営業統括部",
+            "hire_date": "2020-06-01",
+            "annual_salary": 20000000
+          }
+        ]
+      },
+      "financial_data": {
+        "total_assets_billion_yen": 2500,
+        "branches": 85,
+        "customers": 1200000
+      }
+    },
+    {
+      "id": "MB002",
+      "name": "みずほ銀行桜花支店",
+      "type": "都市銀行支店",
+      "bank_name": "みずほ銀行",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区銀行通り2-2-2",
+        "coordinates": {"lat": 35.7070, "lng": 139.8430}
+      },
+      "facility_info": {
+        "floors": 8,
+        "atm_count": 12,
+        "consultation_booths": 15
+      },
+      "employees": {
+        "total": 234,
+        "bankers": 89,
+        "tellers": 56,
+        "loan_officers": 34,
+        "administrative": 55
+      },
+      "services": {
+        "retail_banking": true,
+        "corporate_banking": true,
+        "foreign_exchange": true
+      }
+    },
+    {
+      "id": "MB003",
+      "name": "三菱UFJ銀行桜花支店",
+      "type": "都市銀行支店",
+      "bank_name": "三菱UFJ銀行",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区金融通り3-3-3"
+      },
+      "employees": {
+        "total": 198,
+        "bankers": 78,
+        "tellers": 45,
+        "loan_officers": 30,
+        "administrative": 45
+      }
+    },
+    {
+      "id": "MB004",
+      "name": "桜川信用金庫本店",
+      "type": "信用金庫本店",
+      "bank_name": "桜川信用金庫",
+      "location": {
+        "city": "桜川市",
+        "district": "中央地区",
+        "address": "桜川市中央地区信金通り1-1"
+      },
+      "employees": {
+        "total": 456,
+        "bankers": 234,
+        "tellers": 123,
+        "administrative": 99
+      },
+      "financial_data": {
+        "total_assets_billion_yen": 450,
+        "branches": 25,
+        "members": 85000
+      }
+    }
+  ],
+  "regional_banks": [
+    {
+      "id": "RB001",
+      "name": "桜花銀行中央支店",
+      "type": "地方銀行支店",
+      "bank_name": "桜花銀行",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区商店街2-3"
+      },
+      "employees": {
+        "total": 45,
+        "bankers": 20,
+        "tellers": 15,
+        "administrative": 10
+      }
+    },
+    {
+      "id": "RB002",
+      "name": "桜花銀行東支店",
+      "type": "地方銀行支店",
+      "bank_name": "桜花銀行",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区東通り3-4"
+      },
+      "employees": {
+        "total": 38,
+        "bankers": 18,
+        "tellers": 12,
+        "administrative": 8
+      }
+    }
+  ],
+  "securities_companies": [
+    {
+      "id": "SC001",
+      "name": "桜花証券本社",
+      "type": "証券会社本社",
+      "company_name": "桜花証券株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "金融街",
+        "address": "桜花市金融街2-2-2",
+        "coordinates": {"lat": 35.7095, "lng": 139.8445}
+      },
+      "facility_info": {
+        "floors": 15,
+        "trading_floor": true,
+        "seminar_rooms": 8,
+        "vip_lounges": 3
+      },
+      "employees": {
+        "total": 567,
+        "traders": 123,
+        "analysts": 89,
+        "brokers": 156,
+        "compliance": 45,
+        "it_staff": 67,
+        "administrative": 87,
+        "management": [
+          {
+            "employee_id": "SC001-M001",
+            "name": "社長田投資",
+            "position": "代表取締役社長",
+            "department": "経営企画部",
+            "hire_date": "2018-04-01",
+            "annual_salary": 30000000
+          }
+        ]
+      },
+      "services": {
+        "stock_trading": true,
+        "bond_trading": true,
+        "investment_trust": true,
+        "ipo_underwriting": true,
+        "wealth_management": true
+      },
+      "trading_volume_daily_billion_yen": 150
+    },
+    {
+      "id": "SC002",
+      "name": "野村證券桜花支店",
+      "type": "証券会社支店",
+      "company_name": "野村證券",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区証券通り1-2"
+      },
+      "employees": {
+        "total": 89,
+        "brokers": 45,
+        "analysts": 12,
+        "administrative": 32
+      }
+    }
+  ],
+  "insurance_companies": [
+    {
+      "id": "IC001",
+      "name": "桜花生命保険本社",
+      "type": "生命保険会社本社",
+      "company_name": "桜花生命保険相互会社",
+      "location": {
+        "city": "桜花市",
+        "district": "保険街",
+        "address": "桜花市保険街1-1-1",
+        "coordinates": {"lat": 35.7110, "lng": 139.8460}
+      },
+      "facility_info": {
+        "floors": 25,
+        "customer_service_center": true,
+        "medical_examination_center": true,
+        "conference_halls": 5
+      },
+      "employees": {
+        "total": 2345,
+        "sales_agents": 1234,
+        "underwriters": 234,
+        "actuaries": 45,
+        "claims_processors": 156,
+        "customer_service": 345,
+        "it_staff": 123,
+        "administrative": 208,
+        "management": [
+          {
+            "employee_id": "IC001-M001",
+            "name": "社長田保険",
+            "position": "代表取締役社長",
+            "department": "経営企画部",
+            "hire_date": "2017-04-01",
+            "annual_salary": 28000000
+          }
+        ]
+      },
+      "business_data": {
+        "policies_in_force": 850000,
+        "annual_premium_billion_yen": 320,
+        "branches": 45
+      }
+    },
+    {
+      "id": "IC002",
+      "name": "桜花損害保険本社",
+      "type": "損害保険会社本社",
+      "company_name": "桜花損害保険株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "保険街",
+        "address": "桜花市保険街2-2-2"
+      },
+      "employees": {
+        "total": 1567,
+        "sales_agents": 789,
+        "underwriters": 189,
+        "claims_adjusters": 234,
+        "administrative": 355
+      },
+      "business_data": {
+        "auto_insurance_policies": 450000,
+        "property_insurance_policies": 280000,
+        "annual_premium_billion_yen": 180
+      }
+    },
+    {
+      "id": "IC003",
+      "name": "日本生命桜花支社",
+      "type": "生命保険会社支社",
+      "company_name": "日本生命保険",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区保険通り3-3"
+      },
+      "employees": {
+        "total": 156,
+        "sales_agents": 89,
+        "customer_service": 34,
+        "administrative": 33
+      }
+    }
+  ],
+  "credit_unions": [
+    {
+      "id": "CU001",
+      "name": "桜花市職員信用組合",
+      "type": "職域信用組合",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区市役所通り2-3"
+      },
+      "employees": {
+        "total": 23,
+        "loan_officers": 8,
+        "tellers": 10,
+        "administrative": 5
+      },
+      "members": 3500
+    },
+    {
+      "id": "CU002",
+      "name": "桜県医師信用組合",
+      "type": "職域信用組合",
+      "location": {
+        "city": "桜花市",
+        "district": "医療地区",
+        "address": "桜花市医療地区組合通り1-1"
+      },
+      "employees": {
+        "total": 34,
+        "loan_officers": 12,
+        "tellers": 15,
+        "administrative": 7
+      },
+      "members": 2800
+    }
+  ],
+  "consumer_finance": [
+    {
+      "id": "CF001",
+      "name": "桜花ファイナンス本店",
+      "type": "消費者金融",
+      "company_name": "桜花ファイナンス株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区ローン通り1-1"
+      },
+      "employees": {
+        "total": 67,
+        "loan_officers": 34,
+        "customer_service": 23,
+        "administrative": 10
+      },
+      "branches": 8
+    }
+  ],
+  "credit_card_companies": [
+    {
+      "id": "CC001",
+      "name": "桜花カード本社",
+      "type": "クレジットカード会社",
+      "company_name": "桜花カード株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "金融街",
+        "address": "桜花市金融街3-3-3"
+      },
+      "employees": {
+        "total": 456,
+        "customer_service": 234,
+        "it_staff": 89,
+        "fraud_prevention": 45,
+        "marketing": 34,
+        "administrative": 54
+      },
+      "card_holders": 680000
+    }
+  ],
+  "asset_management": [
+    {
+      "id": "AM001",
+      "name": "桜花アセットマネジメント",
+      "type": "資産運用会社",
+      "location": {
+        "city": "桜花市",
+        "district": "金融街",
+        "address": "桜花市金融街4-4-4"
+      },
+      "employees": {
+        "total": 234,
+        "fund_managers": 45,
+        "analysts": 67,
+        "traders": 34,
+        "compliance": 23,
+        "administrative": 65
+      },
+      "assets_under_management_billion_yen": 1200
+    }
+  ],
+  "fintech_companies": [
+    {
+      "id": "FT001",
+      "name": "桜花ペイメント株式会社",
+      "type": "フィンテック企業",
+      "specialization": "決済サービス",
+      "location": {
+        "city": "桜花市",
+        "district": "IT地区",
+        "address": "桜花市IT地区テクノロジー通り1-1"
+      },
+      "employees": {
+        "total": 345,
+        "engineers": 234,
+        "product_managers": 34,
+        "sales": 45,
+        "administrative": 32
+      },
+      "users": 2500000,
+      "daily_transactions": 1200000
+    },
+    {
+      "id": "FT002",
+      "name": "桜花ロボアドバイザー",
+      "type": "フィンテック企業",
+      "specialization": "自動資産運用",
+      "location": {
+        "city": "桜花市",
+        "district": "IT地区",
+        "address": "桜花市IT地区AI通り2-2"
+      },
+      "employees": {
+        "total": 89,
+        "engineers": 56,
+        "data_scientists": 23,
+        "administrative": 10
+      }
+    }
+  ],
+  "accounting_firms": [
+    {
+      "id": "AF001",
+      "name": "桜花監査法人",
+      "type": "監査法人",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街会計通り1-1"
+      },
+      "employees": {
+        "total": 456,
+        "cpas": 234,
+        "junior_accountants": 156,
+        "administrative": 66,
+        "management": [
+          {
+            "employee_id": "AF001-M001",
+            "name": "代表田監査",
+            "position": "代表社員",
+            "qualification": "公認会計士",
+            "hire_date": "2015-07-01",
+            "annual_salary": 20000000
+          }
+        ]
+      },
+      "clients": 450
+    },
+    {
+      "id": "AF002",
+      "name": "EY新日本有限責任監査法人桜花事務所",
+      "type": "監査法人事務所",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街監査通り2-2"
+      },
+      "employees": {
+        "total": 123,
+        "cpas": 67,
+        "junior_accountants": 45,
+        "administrative": 11
+      }
+    }
+  ],
+  "tax_accounting_offices": [
+    {
+      "id": "TA001",
+      "name": "桜花税理士法人",
+      "type": "税理士法人",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街税務通り1-1"
+      },
+      "employees": {
+        "total": 89,
+        "tax_accountants": 34,
+        "assistants": 45,
+        "administrative": 10
+      },
+      "clients": 1200
+    }
+  ],
+  "financial_consultants": [
+    {
+      "id": "FC001",
+      "name": "桜花ファイナンシャルプランナーズ",
+      "type": "FP事務所",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区相談通り1-1"
+      },
+      "employees": {
+        "total": 34,
+        "certified_fps": 23,
+        "assistants": 8,
+        "administrative": 3
+      }
+    }
+  ],
+  "atm_locations": [
+    {
+      "id": "ATM001",
+      "name": "桜花駅前ATMコーナー",
+      "type": "ATM設置場所",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区駅構内"
+      },
+      "atm_count": 15,
+      "banks": ["桜花銀行", "みずほ銀行", "三菱UFJ銀行", "ゆうちょ銀行"],
+      "24h_service": true
+    }
+  ],
+  "summary": {
+    "total_financial_employees": 12890,
+    "banks": 145,
+    "securities_companies": 23,
+    "insurance_companies": 34,
+    "other_financial": 67,
+    "atm_total": 2345,
+    "financial_coverage": "充実した金融サービスで地域経済を支援"
+  }
+}

--- a/sakura-ken/data/government-public-services.json
+++ b/sakura-ken/data/government-public-services.json
@@ -1,0 +1,606 @@
+{
+  "prefectural_government": [
+    {
+      "id": "PG001",
+      "name": "桜県庁本庁舎",
+      "type": "県庁",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区県庁通り1-1",
+        "coordinates": {"lat": 35.7050, "lng": 139.8400},
+        "area_m2": 45000
+      },
+      "facility_info": {
+        "established": "1871-04-01",
+        "current_building": "1985-03-15",
+        "floors": 15,
+        "underground_floors": 3,
+        "meeting_rooms": 45,
+        "auditorium_capacity": 500
+      },
+      "departments": [
+        "知事室", "総務部", "企画政策部", "財政部", "県民生活部",
+        "環境部", "健康福祉部", "商工労働部", "農林水産部", "建設部",
+        "都市整備部", "教育委員会", "警察本部"
+      ],
+      "employees": {
+        "total": 3456,
+        "administrative": 2345,
+        "technical": 789,
+        "executive": 45,
+        "support": 277,
+        "management": [
+          {
+            "employee_id": "PG001-M001",
+            "name": "知事田行政",
+            "position": "知事",
+            "department": "知事室",
+            "hire_date": "2020-04-01",
+            "term_end": "2024-03-31",
+            "annual_salary": 25000000
+          },
+          {
+            "employee_id": "PG001-M002",
+            "name": "副知事田補佐",
+            "position": "副知事",
+            "department": "知事室",
+            "hire_date": "2020-04-01",
+            "annual_salary": 18000000
+          },
+          {
+            "employee_id": "PG001-M003",
+            "name": "総務田管理",
+            "position": "総務部長",
+            "department": "総務部",
+            "hire_date": "2018-04-01",
+            "annual_salary": 12000000
+          }
+        ]
+      },
+      "services": {
+        "public_counters": 25,
+        "online_services": 150,
+        "annual_visitors": 450000
+      }
+    },
+    {
+      "id": "PG002",
+      "name": "桜県庁別館",
+      "type": "県庁別館",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区県庁通り1-2"
+      },
+      "departments": [
+        "監査委員事務局", "人事委員会", "労働委員会", "選挙管理委員会"
+      ],
+      "employees": {
+        "total": 234,
+        "administrative": 189,
+        "support": 45
+      }
+    }
+  ],
+  "city_halls": [
+    {
+      "id": "CH001",
+      "name": "桜花市役所",
+      "type": "市役所",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区市役所通り2-2",
+        "coordinates": {"lat": 35.7080, "lng": 139.8420}
+      },
+      "facility_info": {
+        "floors": 10,
+        "public_service_floors": 3,
+        "parking_spaces": 500
+      },
+      "departments": [
+        "市長室", "総務課", "市民課", "税務課", "福祉課", "子育て支援課",
+        "環境課", "都市計画課", "建設課", "教育委員会"
+      ],
+      "employees": {
+        "total": 1234,
+        "administrative": 890,
+        "technical": 234,
+        "executive": 20,
+        "support": 90,
+        "management": [
+          {
+            "employee_id": "CH001-M001",
+            "name": "市長田地方",
+            "position": "市長",
+            "department": "市長室",
+            "hire_date": "2019-04-01",
+            "annual_salary": 18000000
+          }
+        ]
+      },
+      "services": {
+        "resident_registration": true,
+        "tax_payment": true,
+        "welfare_consultation": true,
+        "daily_visitors": 1200
+      }
+    },
+    {
+      "id": "CH002",
+      "name": "桜川市役所",
+      "type": "市役所",
+      "location": {
+        "city": "桜川市",
+        "district": "中央地区",
+        "address": "桜川市中央地区市民通り1-1"
+      },
+      "employees": {
+        "total": 890,
+        "administrative": 678,
+        "technical": 156,
+        "support": 56
+      }
+    }
+  ],
+  "ward_offices": [
+    {
+      "id": "WO001",
+      "name": "桜花市中央区役所",
+      "type": "区役所",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区区役所通り1-1"
+      },
+      "employees": {
+        "total": 234,
+        "administrative": 189,
+        "support": 45
+      },
+      "services": {
+        "resident_services": true,
+        "community_center": true,
+        "daily_visitors": 500
+      }
+    },
+    {
+      "id": "WO002",
+      "name": "桜花市東区役所",
+      "type": "区役所",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区行政通り2-2"
+      },
+      "employees": {
+        "total": 198,
+        "administrative": 156,
+        "support": 42
+      }
+    }
+  ],
+  "police_stations": [
+    {
+      "id": "PS001",
+      "name": "桜花中央警察署",
+      "type": "警察署",
+      "jurisdiction": "桜花市中央区・西区",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区警察通り1-1",
+        "coordinates": {"lat": 35.7100, "lng": 139.8450}
+      },
+      "facility_info": {
+        "floors": 6,
+        "detention_cells": 20,
+        "parking_spaces": 150,
+        "helipad": true
+      },
+      "employees": {
+        "total": 456,
+        "police_officers": 345,
+        "detectives": 67,
+        "administrative": 44,
+        "management": [
+          {
+            "employee_id": "PS001-M001",
+            "name": "署長田治安",
+            "position": "警察署長",
+            "rank": "警視",
+            "hire_date": "2019-04-01",
+            "annual_salary": 10000000
+          },
+          {
+            "employee_id": "PS001-M002",
+            "name": "副署長田捜査",
+            "position": "副署長",
+            "rank": "警部",
+            "hire_date": "2020-04-01",
+            "annual_salary": 8000000
+          }
+        ]
+      },
+      "equipment": {
+        "patrol_cars": 45,
+        "motorcycles": 20,
+        "bicycles": 50
+      },
+      "jurisdiction_population": 450000
+    },
+    {
+      "id": "PS002",
+      "name": "桜花東警察署",
+      "type": "警察署",
+      "jurisdiction": "桜花市東区・南区",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区安全通り2-2"
+      },
+      "employees": {
+        "total": 389,
+        "police_officers": 298,
+        "detectives": 56,
+        "administrative": 35
+      }
+    }
+  ],
+  "fire_stations": [
+    {
+      "id": "FS001",
+      "name": "桜花市消防本部",
+      "type": "消防本部",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区消防通り1-1",
+        "coordinates": {"lat": 35.7120, "lng": 139.8480}
+      },
+      "facility_info": {
+        "floors": 5,
+        "training_tower": true,
+        "command_center": true,
+        "garage_bays": 20
+      },
+      "employees": {
+        "total": 678,
+        "firefighters": 523,
+        "paramedics": 89,
+        "administrative": 66,
+        "management": [
+          {
+            "employee_id": "FS001-M001",
+            "name": "消防田防災",
+            "position": "消防長",
+            "rank": "消防司監",
+            "hire_date": "2018-04-01",
+            "annual_salary": 11000000
+          }
+        ]
+      },
+      "equipment": {
+        "fire_engines": 25,
+        "ladder_trucks": 8,
+        "rescue_vehicles": 10,
+        "ambulances": 15
+      },
+      "response_area_population": 600000
+    },
+    {
+      "id": "FS002",
+      "name": "桜花市東消防署",
+      "type": "消防署",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区防災通り2-2"
+      },
+      "employees": {
+        "total": 156,
+        "firefighters": 120,
+        "paramedics": 24,
+        "administrative": 12
+      }
+    }
+  ],
+  "tax_offices": [
+    {
+      "id": "TO001",
+      "name": "桜花税務署",
+      "type": "税務署",
+      "jurisdiction": "桜花市全域",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区税務通り3-3"
+      },
+      "employees": {
+        "total": 234,
+        "tax_officers": 178,
+        "administrative": 56,
+        "management": [
+          {
+            "employee_id": "TO001-M001",
+            "name": "税務田徴収",
+            "position": "署長",
+            "hire_date": "2019-07-01",
+            "annual_salary": 9000000
+          }
+        ]
+      },
+      "services": {
+        "individual_tax": true,
+        "corporate_tax": true,
+        "consultation_rooms": 10
+      }
+    }
+  ],
+  "employment_offices": [
+    {
+      "id": "EO001",
+      "name": "ハローワーク桜花",
+      "type": "公共職業安定所",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区雇用通り1-1"
+      },
+      "facility_info": {
+        "consultation_booths": 20,
+        "seminar_rooms": 5,
+        "computer_terminals": 50
+      },
+      "employees": {
+        "total": 89,
+        "counselors": 56,
+        "administrative": 33
+      },
+      "services": {
+        "job_placement": true,
+        "unemployment_benefits": true,
+        "career_counseling": true,
+        "daily_visitors": 800
+      }
+    }
+  ],
+  "pension_offices": [
+    {
+      "id": "PO001",
+      "name": "桜花年金事務所",
+      "type": "年金事務所",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区年金通り4-4"
+      },
+      "employees": {
+        "total": 78,
+        "counselors": 45,
+        "administrative": 33
+      },
+      "services": {
+        "pension_consultation": true,
+        "record_management": true,
+        "daily_visitors": 450
+      }
+    }
+  ],
+  "legal_affairs_offices": [
+    {
+      "id": "LA001",
+      "name": "桜花地方法務局",
+      "type": "法務局",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区法務通り5-5"
+      },
+      "employees": {
+        "total": 156,
+        "legal_officers": 89,
+        "registrars": 45,
+        "administrative": 22
+      },
+      "services": {
+        "real_estate_registration": true,
+        "commercial_registration": true,
+        "nationality_affairs": true
+      }
+    }
+  ],
+  "courts": [
+    {
+      "id": "CT001",
+      "name": "桜花地方裁判所",
+      "type": "地方裁判所",
+      "location": {
+        "city": "桜花市",
+        "district": "司法地区",
+        "address": "桜花市司法地区裁判所通り1-1"
+      },
+      "facility_info": {
+        "courtrooms": 15,
+        "judges_chambers": 25,
+        "mediation_rooms": 10
+      },
+      "employees": {
+        "total": 234,
+        "judges": 25,
+        "court_clerks": 156,
+        "administrative": 53
+      }
+    },
+    {
+      "id": "CT002",
+      "name": "桜花家庭裁判所",
+      "type": "家庭裁判所",
+      "location": {
+        "city": "桜花市",
+        "district": "司法地区",
+        "address": "桜花市司法地区裁判所通り1-2"
+      },
+      "employees": {
+        "total": 89,
+        "judges": 8,
+        "court_clerks": 56,
+        "family_court_investigators": 25
+      }
+    }
+  ],
+  "public_prosecutors_offices": [
+    {
+      "id": "PP001",
+      "name": "桜花地方検察庁",
+      "type": "地方検察庁",
+      "location": {
+        "city": "桜花市",
+        "district": "司法地区",
+        "address": "桜花市司法地区検察通り2-1"
+      },
+      "employees": {
+        "total": 156,
+        "prosecutors": 45,
+        "assistant_prosecutors": 67,
+        "administrative": 44
+      }
+    }
+  ],
+  "immigration_offices": [
+    {
+      "id": "IO001",
+      "name": "桜花出入国在留管理局",
+      "type": "入管局支局",
+      "location": {
+        "city": "桜花市",
+        "district": "国際地区",
+        "address": "桜花市国際地区入管通り1-1"
+      },
+      "employees": {
+        "total": 89,
+        "immigration_officers": 56,
+        "administrative": 33
+      },
+      "services": {
+        "visa_applications": true,
+        "residence_permits": true,
+        "daily_visitors": 300
+      }
+    }
+  ],
+  "community_centers": [
+    {
+      "id": "CC001",
+      "name": "桜花市中央公民館",
+      "type": "公民館",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区市民活動通り1-1"
+      },
+      "facility_info": {
+        "meeting_rooms": 12,
+        "multipurpose_hall": 1,
+        "kitchen": 2,
+        "library": 1
+      },
+      "employees": {
+        "total": 12,
+        "coordinators": 6,
+        "administrative": 4,
+        "maintenance": 2
+      },
+      "activities": {
+        "courses": 45,
+        "annual_users": 65000
+      }
+    }
+  ],
+  "social_welfare_offices": [
+    {
+      "id": "SW001",
+      "name": "桜花市社会福祉事務所",
+      "type": "福祉事務所",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区福祉通り2-2"
+      },
+      "employees": {
+        "total": 123,
+        "social_workers": 78,
+        "counselors": 34,
+        "administrative": 11
+      },
+      "services": {
+        "welfare_consultation": true,
+        "child_welfare": true,
+        "disability_support": true
+      }
+    }
+  ],
+  "health_centers": [
+    {
+      "id": "HC001",
+      "name": "桜花市保健所",
+      "type": "保健所",
+      "location": {
+        "city": "桜花市",
+        "district": "健康地区",
+        "address": "桜花市健康地区保健通り1-1"
+      },
+      "employees": {
+        "total": 145,
+        "public_health_doctors": 12,
+        "public_health_nurses": 67,
+        "inspectors": 34,
+        "administrative": 32
+      },
+      "services": {
+        "health_consultation": true,
+        "vaccination": true,
+        "food_safety_inspection": true
+      }
+    }
+  ],
+  "driver_license_centers": [
+    {
+      "id": "DL001",
+      "name": "桜県運転免許センター",
+      "type": "運転免許センター",
+      "location": {
+        "city": "桜花市",
+        "district": "交通地区",
+        "address": "桜花市交通地区免許通り1-1"
+      },
+      "facility_info": {
+        "testing_rooms": 10,
+        "driving_course": true,
+        "photo_booths": 20
+      },
+      "employees": {
+        "total": 234,
+        "examiners": 89,
+        "instructors": 56,
+        "administrative": 89
+      },
+      "services": {
+        "license_renewal": true,
+        "written_tests": true,
+        "driving_tests": true,
+        "daily_visitors": 1500
+      }
+    }
+  ],
+  "summary": {
+    "total_public_employees": 14567,
+    "prefectural_employees": 3690,
+    "municipal_employees": 6234,
+    "police_officers": 1890,
+    "firefighters": 1567,
+    "judicial_employees": 1186,
+    "service_coverage": "包括的な行政サービスで全住民に対応"
+  }
+}

--- a/sakura-ken/data/healthcare-facilities.json
+++ b/sakura-ken/data/healthcare-facilities.json
@@ -1,0 +1,494 @@
+{
+  "hospitals": [
+    {
+      "id": "HP001",
+      "name": "桜県立中央病院",
+      "type": "総合病院",
+      "specialization": "三次救急医療機関",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区医療センター街1-1",
+        "coordinates": {"lat": 35.7100, "lng": 139.8500},
+        "area_m2": 85000
+      },
+      "facility_info": {
+        "established": "1950-04-01",
+        "buildings": 6,
+        "floors": 12,
+        "beds": 850,
+        "emergency_rooms": 15,
+        "operating_rooms": 24,
+        "icu_beds": 60,
+        "parking_spaces": 1200
+      },
+      "departments": [
+        "内科", "外科", "小児科", "産婦人科", "整形外科", "脳神経外科",
+        "心臓血管外科", "皮膚科", "眼科", "耳鼻咽喉科", "精神科", "救急科"
+      ],
+      "equipment": {
+        "mri": 4,
+        "ct_scanners": 6,
+        "surgical_robots": 2,
+        "dialysis_units": 30
+      },
+      "employees": {
+        "total": 2456,
+        "doctors": 425,
+        "nurses": 1234,
+        "technicians": 234,
+        "administrative": 456,
+        "management": [
+          {
+            "employee_id": "HP001-M001",
+            "name": "医療田総合",
+            "position": "院長",
+            "department": "病院管理部",
+            "specialization": "循環器内科",
+            "hire_date": "2010-04-01",
+            "annual_salary": 25000000
+          },
+          {
+            "employee_id": "HP001-M002",
+            "name": "看護田管理",
+            "position": "看護部長",
+            "department": "看護部",
+            "hire_date": "2005-04-01",
+            "annual_salary": 12000000
+          }
+        ],
+        "sample_doctors": [
+          {
+            "employee_id": "HP001-D001",
+            "name": "心臓田健康",
+            "position": "主任医師",
+            "department": "循環器内科",
+            "specialization": "心臓カテーテル治療",
+            "hire_date": "2015-04-01",
+            "annual_salary": 18000000
+          },
+          {
+            "employee_id": "HP001-D002",
+            "name": "脳田神経",
+            "position": "部長",
+            "department": "脳神経外科",
+            "specialization": "脳腫瘍手術",
+            "hire_date": "2012-04-01",
+            "annual_salary": 20000000
+          }
+        ]
+      },
+      "services": {
+        "24h_emergency": true,
+        "helicopter_pad": true,
+        "ambulance_fleet": 12,
+        "telemedicine": true,
+        "international_clinic": true
+      },
+      "annual_patients": 450000,
+      "annual_operations": 12000
+    },
+    {
+      "id": "HP002",
+      "name": "桜花市立総合医療センター",
+      "type": "地域中核病院",
+      "specialization": "二次救急医療機関",
+      "location": {
+        "city": "桜花市",
+        "district": "西区",
+        "address": "桜花市西区健康の森2-3-4",
+        "coordinates": {"lat": 35.6950, "lng": 139.8200},
+        "area_m2": 55000
+      },
+      "facility_info": {
+        "established": "1965-06-01",
+        "buildings": 4,
+        "floors": 8,
+        "beds": 520,
+        "emergency_rooms": 8,
+        "operating_rooms": 12,
+        "icu_beds": 24,
+        "parking_spaces": 800
+      },
+      "departments": [
+        "内科", "外科", "小児科", "産婦人科", "整形外科",
+        "皮膚科", "眼科", "耳鼻咽喉科", "リハビリテーション科"
+      ],
+      "employees": {
+        "total": 1567,
+        "doctors": 234,
+        "nurses": 789,
+        "technicians": 156,
+        "administrative": 345,
+        "management": [
+          {
+            "employee_id": "HP002-M001",
+            "name": "地域田医療",
+            "position": "院長",
+            "department": "病院管理部",
+            "specialization": "消化器内科",
+            "hire_date": "2012-04-01",
+            "annual_salary": 20000000
+          }
+        ]
+      },
+      "annual_patients": 280000,
+      "annual_operations": 6500
+    },
+    {
+      "id": "HP003",
+      "name": "さくら川市民病院",
+      "type": "市民病院",
+      "specialization": "二次救急医療機関",
+      "location": {
+        "city": "桜川市",
+        "district": "中央地区",
+        "address": "桜川市中央地区健康通り5-6-7",
+        "coordinates": {"lat": 35.6800, "lng": 139.9100},
+        "area_m2": 42000
+      },
+      "facility_info": {
+        "established": "1970-04-01",
+        "buildings": 3,
+        "floors": 7,
+        "beds": 380,
+        "emergency_rooms": 6,
+        "operating_rooms": 8,
+        "parking_spaces": 600
+      },
+      "employees": {
+        "total": 1234,
+        "doctors": 178,
+        "nurses": 623,
+        "technicians": 123,
+        "administrative": 267
+      },
+      "annual_patients": 210000
+    }
+  ],
+  "specialized_hospitals": [
+    {
+      "id": "SH001",
+      "name": "桜県立がんセンター",
+      "type": "専門病院",
+      "specialization": "がん治療",
+      "location": {
+        "city": "桜花市",
+        "district": "北区",
+        "address": "桜花市北区医療研究地区3-2-1",
+        "coordinates": {"lat": 35.7300, "lng": 139.8600},
+        "area_m2": 38000
+      },
+      "facility_info": {
+        "established": "1985-04-01",
+        "beds": 300,
+        "radiation_therapy_units": 6,
+        "chemotherapy_chairs": 50
+      },
+      "employees": {
+        "total": 856,
+        "doctors": 145,
+        "nurses": 432,
+        "researchers": 89,
+        "management": [
+          {
+            "employee_id": "SH001-M001",
+            "name": "癌田治療",
+            "position": "センター長",
+            "specialization": "腫瘍内科",
+            "hire_date": "2008-04-01",
+            "annual_salary": 22000000
+          }
+        ]
+      },
+      "annual_patients": 85000
+    },
+    {
+      "id": "SH002",
+      "name": "桜県立こども医療センター",
+      "type": "専門病院",
+      "specialization": "小児医療",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区こども健康街4-5-6",
+        "coordinates": {"lat": 35.7150, "lng": 139.8800}
+      },
+      "facility_info": {
+        "established": "1990-04-01",
+        "beds": 200,
+        "nicu_beds": 30,
+        "picu_beds": 20
+      },
+      "employees": {
+        "total": 678,
+        "doctors": 123,
+        "nurses": 345,
+        "child_life_specialists": 15
+      },
+      "annual_patients": 120000
+    }
+  ],
+  "clinics": [
+    {
+      "id": "CL001",
+      "name": "さくら内科クリニック",
+      "type": "診療所",
+      "specialization": "内科・循環器内科",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区駅前通り2-3-4",
+        "coordinates": {"lat": 35.7080, "lng": 139.8450}
+      },
+      "facility_info": {
+        "established": "2005-05-01",
+        "examination_rooms": 4,
+        "parking_spaces": 20
+      },
+      "employees": {
+        "total": 12,
+        "doctors": 2,
+        "nurses": 5,
+        "administrative": 5,
+        "management": [
+          {
+            "employee_id": "CL001-M001",
+            "name": "診療田健康",
+            "position": "院長",
+            "specialization": "循環器内科",
+            "hire_date": "2005-05-01",
+            "annual_salary": 15000000
+          }
+        ]
+      },
+      "services": ["健康診断", "予防接種", "生活習慣病管理"],
+      "annual_patients": 18000
+    },
+    {
+      "id": "CL002",
+      "name": "桜花ファミリークリニック",
+      "type": "診療所",
+      "specialization": "家庭医療",
+      "location": {
+        "city": "桜花市",
+        "district": "南区",
+        "address": "桜花市南区住宅街3-4-5"
+      },
+      "employees": {
+        "total": 15,
+        "doctors": 3,
+        "nurses": 6,
+        "administrative": 6
+      },
+      "annual_patients": 22000
+    },
+    {
+      "id": "CL003",
+      "name": "さくら皮膚科クリニック",
+      "type": "診療所",
+      "specialization": "皮膚科・美容皮膚科",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区美容通り1-2-3"
+      },
+      "employees": {
+        "total": 10,
+        "doctors": 2,
+        "nurses": 4,
+        "administrative": 4
+      },
+      "annual_patients": 15000
+    }
+  ],
+  "dental_clinics": [
+    {
+      "id": "DC001",
+      "name": "桜花デンタルクリニック",
+      "type": "歯科診療所",
+      "specialization": "一般歯科・矯正歯科",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区歯科通り1-1-1"
+      },
+      "facility_info": {
+        "treatment_chairs": 8,
+        "ct_scanner": true,
+        "cad_cam": true
+      },
+      "employees": {
+        "total": 18,
+        "dentists": 5,
+        "dental_hygienists": 8,
+        "administrative": 5
+      },
+      "annual_patients": 12000
+    }
+  ],
+  "pharmacies": [
+    {
+      "id": "PH001",
+      "name": "さくら薬局本店",
+      "type": "調剤薬局",
+      "chain": "さくら薬局グループ",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区医療センター街1-2"
+      },
+      "facility_info": {
+        "24h_service": true,
+        "drive_through": true,
+        "otc_section": true
+      },
+      "employees": {
+        "total": 24,
+        "pharmacists": 12,
+        "pharmacy_technicians": 8,
+        "administrative": 4,
+        "management": [
+          {
+            "employee_id": "PH001-M001",
+            "name": "薬田調剤",
+            "position": "管理薬剤師",
+            "license": "薬剤師免許第123456号",
+            "hire_date": "2010-04-01",
+            "annual_salary": 8000000
+          }
+        ]
+      },
+      "prescriptions_per_day": 450
+    },
+    {
+      "id": "PH002",
+      "name": "健康堂薬局桜花店",
+      "type": "調剤薬局・ドラッグストア",
+      "chain": "健康堂",
+      "location": {
+        "city": "桜花市",
+        "district": "西区",
+        "address": "桜花市西区ショッピング街2-3"
+      },
+      "employees": {
+        "total": 18,
+        "pharmacists": 6,
+        "registered_sellers": 8,
+        "administrative": 4
+      },
+      "prescriptions_per_day": 280
+    }
+  ],
+  "elderly_care_facilities": [
+    {
+      "id": "EC001",
+      "name": "桜花園特別養護老人ホーム",
+      "type": "特別養護老人ホーム",
+      "location": {
+        "city": "桜花市",
+        "district": "北区",
+        "address": "桜花市北区福祉の丘1-1"
+      },
+      "facility_info": {
+        "capacity": 120,
+        "private_rooms": 80,
+        "shared_rooms": 20,
+        "day_service_capacity": 40
+      },
+      "employees": {
+        "total": 145,
+        "care_workers": 78,
+        "nurses": 24,
+        "nutritionists": 4,
+        "physical_therapists": 6,
+        "social_workers": 8,
+        "administrative": 25
+      }
+    }
+  ],
+  "rehabilitation_centers": [
+    {
+      "id": "RC001",
+      "name": "桜県リハビリテーションセンター",
+      "type": "リハビリテーション施設",
+      "location": {
+        "city": "桜花市",
+        "district": "南区",
+        "address": "桜花市南区健康増進地区2-1"
+      },
+      "facility_info": {
+        "therapy_rooms": 15,
+        "pool_therapy": true,
+        "robotic_therapy_units": 4
+      },
+      "employees": {
+        "total": 89,
+        "physical_therapists": 34,
+        "occupational_therapists": 28,
+        "speech_therapists": 12,
+        "doctors": 5,
+        "administrative": 10
+      },
+      "daily_patients": 200
+    }
+  ],
+  "medical_laboratories": [
+    {
+      "id": "ML001",
+      "name": "桜県臨床検査センター",
+      "type": "臨床検査施設",
+      "location": {
+        "city": "桜花市",
+        "district": "東区",
+        "address": "桜花市東区バイオパーク3-1"
+      },
+      "facility_info": {
+        "laboratory_floors": 3,
+        "clean_rooms": 8,
+        "automated_analyzers": 25
+      },
+      "employees": {
+        "total": 234,
+        "clinical_technologists": 156,
+        "pathologists": 12,
+        "administrative": 45,
+        "logistics": 21
+      },
+      "daily_tests": 15000
+    }
+  ],
+  "emergency_services": [
+    {
+      "id": "ES001",
+      "name": "桜花市消防局救急センター",
+      "type": "救急サービス",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区緊急通り1-1"
+      },
+      "facility_info": {
+        "ambulance_stations": 8,
+        "ambulances": 45,
+        "rapid_response_vehicles": 12
+      },
+      "employees": {
+        "total": 456,
+        "paramedics": 234,
+        "emergency_medical_technicians": 156,
+        "drivers": 45,
+        "administrative": 21
+      },
+      "annual_calls": 65000
+    }
+  ],
+  "summary": {
+    "total_healthcare_employees": 18234,
+    "total_hospitals": 6,
+    "total_clinics": 150,
+    "total_pharmacies": 234,
+    "total_beds": 3500,
+    "population_coverage": "十分な医療体制で200万人以上の人口に対応"
+  }
+}

--- a/sakura-ken/data/hotels-hospitality.json
+++ b/sakura-ken/data/hotels-hospitality.json
@@ -1,0 +1,557 @@
+{
+  "luxury_hotels": [
+    {
+      "id": "LH001",
+      "name": "桜花グランドホテル",
+      "type": "ラグジュアリーホテル",
+      "rating": "5つ星",
+      "chain": "独立系",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区ホテル通り1-1",
+        "coordinates": {"lat": 35.7075, "lng": 139.8435},
+        "area_m2": 35000
+      },
+      "facility_info": {
+        "floors": 30,
+        "rooms": 450,
+        "suites": 50,
+        "restaurants": 6,
+        "bars": 3,
+        "spa": true,
+        "fitness_center": true,
+        "swimming_pools": 2,
+        "conference_rooms": 12,
+        "ballrooms": 3,
+        "parking_spaces": 500
+      },
+      "room_types": {
+        "standard": 300,
+        "deluxe": 100,
+        "executive": 40,
+        "suites": 10
+      },
+      "employees": {
+        "total": 567,
+        "front_desk": 45,
+        "concierge": 12,
+        "housekeeping": 156,
+        "food_beverage": 189,
+        "spa_fitness": 34,
+        "engineering": 45,
+        "security": 23,
+        "administrative": 63,
+        "management": [
+          {
+            "employee_id": "LH001-M001",
+            "name": "総支配人田接客",
+            "position": "総支配人",
+            "department": "ホテル運営部",
+            "hire_date": "2018-04-01",
+            "annual_salary": 20000000
+          },
+          {
+            "employee_id": "LH001-M002",
+            "name": "料飲田美食",
+            "position": "料飲部長",
+            "department": "料飲部",
+            "hire_date": "2019-04-01",
+            "annual_salary": 12000000
+          }
+        ]
+      },
+      "annual_occupancy_rate": 0.85,
+      "annual_guests": 250000
+    },
+    {
+      "id": "LH002",
+      "name": "ホテル桜花パレス",
+      "type": "ラグジュアリーホテル",
+      "rating": "5つ星",
+      "chain": "インターコンチネンタル",
+      "location": {
+        "city": "桜花市",
+        "district": "湾岸地区",
+        "address": "桜花市湾岸地区オーシャンビュー通り2-2"
+      },
+      "facility_info": {
+        "floors": 25,
+        "rooms": 380,
+        "suites": 40
+      },
+      "employees": {
+        "total": 456,
+        "front_office": 67,
+        "housekeeping": 134,
+        "food_beverage": 156,
+        "administrative": 99
+      }
+    }
+  ],
+  "business_hotels": [
+    {
+      "id": "BH001",
+      "name": "桜花ビジネスホテル",
+      "type": "ビジネスホテル",
+      "rating": "3つ星",
+      "chain": "東横イン",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区ビジネス通り1-1"
+      },
+      "facility_info": {
+        "floors": 12,
+        "rooms": 250,
+        "restaurant": 1,
+        "meeting_rooms": 3,
+        "parking_spaces": 80
+      },
+      "employees": {
+        "total": 89,
+        "front_desk": 15,
+        "housekeeping": 45,
+        "restaurant": 20,
+        "administrative": 9
+      },
+      "annual_occupancy_rate": 0.78
+    },
+    {
+      "id": "BH002",
+      "name": "アパホテル桜花駅前",
+      "type": "ビジネスホテル",
+      "chain": "アパホテル",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区アクセス通り2-2"
+      },
+      "facility_info": {
+        "rooms": 320,
+        "floors": 15
+      },
+      "employees": {
+        "total": 78,
+        "front_desk": 12,
+        "housekeeping": 50,
+        "administrative": 16
+      }
+    }
+  ],
+  "resort_hotels": [
+    {
+      "id": "RH001",
+      "name": "桜花温泉リゾート",
+      "type": "温泉リゾートホテル",
+      "rating": "4つ星",
+      "location": {
+        "city": "桜花市",
+        "district": "温泉地区",
+        "address": "桜花市温泉地区湯の里1-1",
+        "area_m2": 80000
+      },
+      "facility_info": {
+        "buildings": 5,
+        "rooms": 180,
+        "japanese_rooms": 120,
+        "western_rooms": 60,
+        "hot_springs": 8,
+        "private_baths": 12,
+        "restaurants": 4,
+        "gardens_m2": 30000
+      },
+      "employees": {
+        "total": 234,
+        "front_desk": 20,
+        "room_attendants": 67,
+        "spa_staff": 34,
+        "chefs": 45,
+        "gardeners": 12,
+        "administrative": 56
+      },
+      "amenities": ["露天風呂", "岩盤浴", "エステ", "マッサージ", "カラオケ", "ゲームコーナー"]
+    }
+  ],
+  "ryokans": [
+    {
+      "id": "RY001",
+      "name": "老舗旅館 桜花荘",
+      "type": "高級旅館",
+      "established": "1850年",
+      "location": {
+        "city": "桜花市",
+        "district": "歴史地区",
+        "address": "桜花市歴史地区伝統通り1-1"
+      },
+      "facility_info": {
+        "buildings": 3,
+        "rooms": 25,
+        "all_japanese_style": true,
+        "private_hot_springs": 5,
+        "tea_ceremony_room": true,
+        "japanese_garden": true
+      },
+      "employees": {
+        "total": 56,
+        "nakai": 20,
+        "chefs": 12,
+        "front_desk": 6,
+        "maintenance": 8,
+        "administrative": 10,
+        "management": [
+          {
+            "employee_id": "RY001-M001",
+            "name": "女将田伝統",
+            "position": "女将",
+            "hire_date": "1995-04-01",
+            "annual_salary": 15000000
+          }
+        ]
+      },
+      "kaiseki_dining": true
+    }
+  ],
+  "capsule_hotels": [
+    {
+      "id": "CH001",
+      "name": "カプセルイン桜花",
+      "type": "カプセルホテル",
+      "location": {
+        "city": "桜花市",
+        "district": "繁華街",
+        "address": "桜花市繁華街夜通り1-1"
+      },
+      "facility_info": {
+        "capsules": 180,
+        "male_capsules": 120,
+        "female_capsules": 60,
+        "lounge": true,
+        "spa": true
+      },
+      "employees": {
+        "total": 23,
+        "reception": 8,
+        "cleaning": 10,
+        "security": 3,
+        "administrative": 2
+      }
+    }
+  ],
+  "guest_houses": [
+    {
+      "id": "GH001",
+      "name": "ゲストハウス桜花",
+      "type": "ゲストハウス",
+      "location": {
+        "city": "桜花市",
+        "district": "バックパッカー地区",
+        "address": "桜花市バックパッカー地区国際通り1-1"
+      },
+      "facility_info": {
+        "beds": 80,
+        "dormitory_rooms": 10,
+        "private_rooms": 5,
+        "common_kitchen": true,
+        "lounge": true
+      },
+      "employees": {
+        "total": 8,
+        "reception": 4,
+        "cleaning": 3,
+        "administrative": 1
+      }
+    }
+  ],
+  "restaurants": [
+    {
+      "id": "RT001",
+      "name": "桜花料亭",
+      "type": "高級料亭",
+      "cuisine": "懐石料理",
+      "location": {
+        "city": "桜花市",
+        "district": "料亭街",
+        "address": "桜花市料亭街美食通り1-1"
+      },
+      "facility_info": {
+        "seats": 80,
+        "private_rooms": 12,
+        "tea_rooms": 3,
+        "garden_view": true
+      },
+      "employees": {
+        "total": 45,
+        "head_chef": 1,
+        "chefs": 12,
+        "service_staff": 20,
+        "administrative": 12
+      },
+      "michelin_stars": 2
+    },
+    {
+      "id": "RT002",
+      "name": "桜花ビストロ",
+      "type": "カジュアルレストラン",
+      "cuisine": "フレンチ",
+      "location": {
+        "city": "桜花市",
+        "district": "グルメ地区",
+        "address": "桜花市グルメ地区洋食通り2-2"
+      },
+      "facility_info": {
+        "seats": 120,
+        "bar_counter": 15,
+        "terrace": true
+      },
+      "employees": {
+        "total": 34,
+        "chefs": 8,
+        "service_staff": 18,
+        "bartenders": 3,
+        "administrative": 5
+      }
+    }
+  ],
+  "cafes": [
+    {
+      "id": "CF001",
+      "name": "カフェ桜花",
+      "type": "カフェ",
+      "chain": "独立系",
+      "location": {
+        "city": "桜花市",
+        "district": "文化地区",
+        "address": "桜花市文化地区カフェ通り1-1"
+      },
+      "facility_info": {
+        "seats": 60,
+        "terrace_seats": 20,
+        "wifi": true,
+        "power_outlets": true
+      },
+      "employees": {
+        "total": 12,
+        "baristas": 6,
+        "kitchen": 3,
+        "service": 3
+      },
+      "specialties": ["自家焙煎コーヒー", "手作りケーキ", "サンドイッチ"]
+    },
+    {
+      "id": "CF002",
+      "name": "スターバックス桜花駅前店",
+      "type": "カフェ",
+      "chain": "スターバックス",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区コーヒー通り2-2"
+      },
+      "employees": {
+        "total": 23,
+        "shift_supervisors": 4,
+        "baristas": 16,
+        "administrative": 3
+      }
+    }
+  ],
+  "bars": [
+    {
+      "id": "BR001",
+      "name": "バー桜花",
+      "type": "高級バー",
+      "location": {
+        "city": "桜花市",
+        "district": "夜の街",
+        "address": "桜花市夜の街カクテル通り1-1"
+      },
+      "facility_info": {
+        "seats": 40,
+        "private_rooms": 2,
+        "wine_cellar": true
+      },
+      "employees": {
+        "total": 8,
+        "bartenders": 4,
+        "sommelier": 1,
+        "service": 3
+      },
+      "specialties": ["クラフトカクテル", "ウイスキー", "ワイン"]
+    }
+  ],
+  "izakayas": [
+    {
+      "id": "IZ001",
+      "name": "居酒屋 桜花横丁",
+      "type": "居酒屋",
+      "chain": "独立系",
+      "location": {
+        "city": "桜花市",
+        "district": "飲食街",
+        "address": "桜花市飲食街横丁通り1-1"
+      },
+      "facility_info": {
+        "seats": 80,
+        "counter_seats": 20,
+        "tatami_rooms": 4
+      },
+      "employees": {
+        "total": 23,
+        "chefs": 6,
+        "service_staff": 12,
+        "administrative": 5
+      }
+    }
+  ],
+  "food_courts": [
+    {
+      "id": "FC001",
+      "name": "桜花駅フードコート",
+      "type": "フードコート",
+      "location": {
+        "city": "桜花市",
+        "district": "駅構内",
+        "address": "桜花市駅構内グルメ広場"
+      },
+      "tenants": 12,
+      "total_seats": 400,
+      "employees": {
+        "total": 156,
+        "tenant_staff": 120,
+        "cleaning": 20,
+        "security": 10,
+        "administrative": 6
+      }
+    }
+  ],
+  "catering_services": [
+    {
+      "id": "CS001",
+      "name": "桜花ケータリングサービス",
+      "type": "ケータリング会社",
+      "location": {
+        "city": "桜花市",
+        "district": "産業地区",
+        "address": "桜花市産業地区配送センター通り1-1"
+      },
+      "services": ["企業イベント", "結婚式", "パーティー", "会議"],
+      "employees": {
+        "total": 78,
+        "chefs": 23,
+        "service_staff": 34,
+        "drivers": 12,
+        "administrative": 9
+      },
+      "annual_events": 890
+    }
+  ],
+  "wedding_venues": [
+    {
+      "id": "WV001",
+      "name": "桜花ウェディングパレス",
+      "type": "結婚式場",
+      "location": {
+        "city": "桜花市",
+        "district": "ブライダル地区",
+        "address": "桜花市ブライダル地区幸せ通り1-1"
+      },
+      "facility_info": {
+        "chapels": 2,
+        "banquet_halls": 4,
+        "max_capacity": 500,
+        "gardens": true,
+        "photo_studios": 2
+      },
+      "employees": {
+        "total": 89,
+        "wedding_planners": 23,
+        "service_staff": 34,
+        "chefs": 20,
+        "photographers": 6,
+        "administrative": 6
+      },
+      "annual_weddings": 456
+    }
+  ],
+  "convention_centers": [
+    {
+      "id": "CC001",
+      "name": "桜花国際会議場",
+      "type": "コンベンションセンター",
+      "location": {
+        "city": "桜花市",
+        "district": "国際地区",
+        "address": "桜花市国際地区会議通り1-1"
+      },
+      "facility_info": {
+        "main_hall_capacity": 3000,
+        "meeting_rooms": 20,
+        "exhibition_space_m2": 10000,
+        "simultaneous_interpretation": true
+      },
+      "employees": {
+        "total": 123,
+        "event_coordinators": 34,
+        "technical_staff": 45,
+        "security": 23,
+        "administrative": 21
+      },
+      "annual_events": 234
+    }
+  ],
+  "travel_agencies": [
+    {
+      "id": "TA001",
+      "name": "桜花トラベル",
+      "type": "旅行代理店",
+      "chain": "JTB",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区旅行通り1-1"
+      },
+      "employees": {
+        "total": 34,
+        "travel_consultants": 23,
+        "tour_conductors": 6,
+        "administrative": 5
+      },
+      "annual_customers": 45000
+    }
+  ],
+  "tour_operators": [
+    {
+      "id": "TO001",
+      "name": "桜花観光",
+      "type": "観光会社",
+      "specialization": "市内観光・日帰りツアー",
+      "location": {
+        "city": "桜花市",
+        "district": "観光地区",
+        "address": "桜花市観光地区ツアー通り1-1"
+      },
+      "fleet": {
+        "tour_buses": 12,
+        "vans": 8
+      },
+      "employees": {
+        "total": 45,
+        "tour_guides": 20,
+        "drivers": 15,
+        "administrative": 10
+      },
+      "annual_tourists": 89000
+    }
+  ],
+  "summary": {
+    "total_hospitality_employees": 4567,
+    "hotels": 145,
+    "restaurants_cafes": 890,
+    "bars_izakayas": 234,
+    "wedding_event_venues": 45,
+    "travel_tourism": 123,
+    "total_guest_rooms": 8900,
+    "hospitality_coverage": "充実した宿泊・飲食施設で観光とビジネスをサポート"
+  }
+}

--- a/sakura-ken/data/it-technology-companies.json
+++ b/sakura-ken/data/it-technology-companies.json
@@ -1,0 +1,437 @@
+{
+  "software_companies": [
+    {
+      "id": "SC001",
+      "name": "桜花ソフトウェア株式会社",
+      "type": "ソフトウェア開発企業",
+      "specialization": "エンタープライズソリューション",
+      "location": {
+        "city": "桜花市",
+        "district": "ITパーク",
+        "address": "桜花市ITパーク開発通り1-1",
+        "coordinates": {"lat": 35.7200, "lng": 139.8550},
+        "area_m2": 12000
+      },
+      "facility_info": {
+        "floors": 15,
+        "development_floors": 10,
+        "meeting_rooms": 25,
+        "server_rooms": 3,
+        "recreation_areas": 5
+      },
+      "business_info": {
+        "established": "1995-04-01",
+        "products": ["ERP システム", "CRM ソリューション", "ビジネスインテリジェンス", "クラウドサービス"],
+        "clients": 450,
+        "annual_revenue_million_yen": 8500
+      },
+      "employees": {
+        "total": 1234,
+        "engineers": 890,
+        "product_managers": 78,
+        "designers": 56,
+        "qa_testers": 89,
+        "sales": 67,
+        "administrative": 54,
+        "management": [
+          {
+            "employee_id": "SC001-M001",
+            "name": "社長田開発",
+            "position": "代表取締役社長",
+            "department": "経営企画部",
+            "specialization": "ソフトウェア工学",
+            "hire_date": "2018-04-01",
+            "annual_salary": 25000000
+          },
+          {
+            "employee_id": "SC001-M002",
+            "name": "CTO田技術",
+            "position": "最高技術責任者",
+            "department": "技術統括部",
+            "specialization": "クラウドアーキテクチャ",
+            "hire_date": "2019-04-01",
+            "annual_salary": 20000000
+          }
+        ],
+        "sample_engineers": [
+          {
+            "employee_id": "SC001-E001",
+            "name": "開発田太郎",
+            "position": "シニアエンジニア",
+            "department": "プラットフォーム開発部",
+            "skills": ["Java", "Spring", "AWS", "Kubernetes"],
+            "hire_date": "2015-04-01",
+            "annual_salary": 9000000
+          },
+          {
+            "employee_id": "SC001-E002",
+            "name": "プログラム田花子",
+            "position": "リードエンジニア",
+            "department": "フロントエンド開発部",
+            "skills": ["React", "TypeScript", "Node.js", "GraphQL"],
+            "hire_date": "2017-04-01",
+            "annual_salary": 8500000
+          }
+        ]
+      },
+      "certifications": ["ISO27001", "ISO9001", "CMMI Level 3"]
+    },
+    {
+      "id": "SC002",
+      "name": "桜AIテクノロジー",
+      "type": "AI開発企業",
+      "specialization": "人工知能・機械学習",
+      "location": {
+        "city": "桜花市",
+        "district": "AIバレー",
+        "address": "桜花市AIバレー知能通り2-2"
+      },
+      "business_info": {
+        "products": ["画像認識AI", "自然言語処理", "予測分析", "自動運転技術"],
+        "patents": 67,
+        "research_papers": 234
+      },
+      "employees": {
+        "total": 456,
+        "researchers": 234,
+        "engineers": 156,
+        "data_scientists": 45,
+        "administrative": 21
+      }
+    },
+    {
+      "id": "SC003",
+      "name": "サクラゲームスタジオ",
+      "type": "ゲーム開発会社",
+      "specialization": "モバイル・コンソールゲーム",
+      "location": {
+        "city": "桜花市",
+        "district": "クリエイティブ地区",
+        "address": "桜花市クリエイティブ地区ゲーム通り3-3"
+      },
+      "employees": {
+        "total": 345,
+        "programmers": 123,
+        "game_designers": 67,
+        "artists": 89,
+        "sound_engineers": 23,
+        "qa_testers": 34,
+        "administrative": 9
+      },
+      "released_titles": 45
+    }
+  ],
+  "web_companies": [
+    {
+      "id": "WC001",
+      "name": "桜花ウェブサービス",
+      "type": "Webサービス企業",
+      "specialization": "EC・メディアプラットフォーム",
+      "location": {
+        "city": "桜花市",
+        "district": "デジタル地区",
+        "address": "桜花市デジタル地区Web通り1-1"
+      },
+      "services": ["ECプラットフォーム", "ニュースポータル", "動画配信", "SNS"],
+      "employees": {
+        "total": 567,
+        "engineers": 345,
+        "content_creators": 89,
+        "marketing": 67,
+        "customer_support": 45,
+        "administrative": 21
+      },
+      "monthly_active_users": 5000000
+    },
+    {
+      "id": "WC002",
+      "name": "桜デジタルマーケティング",
+      "type": "デジタルマーケティング",
+      "specialization": "SEO・広告運用",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街マーケティング通り2-2"
+      },
+      "employees": {
+        "total": 123,
+        "marketers": 67,
+        "data_analysts": 34,
+        "designers": 12,
+        "administrative": 10
+      },
+      "clients": 890
+    }
+  ],
+  "it_services": [
+    {
+      "id": "IT001",
+      "name": "桜花システムインテグレーション",
+      "type": "システムインテグレーター",
+      "specialization": "ITインフラ・クラウド移行",
+      "location": {
+        "city": "桜花市",
+        "district": "ITパーク",
+        "address": "桜花市ITパークインフラ通り2-2"
+      },
+      "employees": {
+        "total": 789,
+        "system_engineers": 456,
+        "network_engineers": 123,
+        "cloud_architects": 89,
+        "project_managers": 67,
+        "sales": 34,
+        "administrative": 20
+      },
+      "certifications": ["AWS Partner", "Microsoft Gold Partner", "Google Cloud Partner"]
+    },
+    {
+      "id": "IT002",
+      "name": "桜ITコンサルティング",
+      "type": "ITコンサルティング",
+      "specialization": "DX推進・業務改革",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街コンサル通り3-3"
+      },
+      "employees": {
+        "total": 234,
+        "consultants": 156,
+        "analysts": 45,
+        "administrative": 33
+      }
+    }
+  ],
+  "cybersecurity_companies": [
+    {
+      "id": "CS001",
+      "name": "桜花サイバーセキュリティ",
+      "type": "セキュリティ企業",
+      "specialization": "脅威対策・SOC運用",
+      "location": {
+        "city": "桜花市",
+        "district": "セキュリティ地区",
+        "address": "桜花市セキュリティ地区防御通り1-1"
+      },
+      "facility_info": {
+        "soc_center": true,
+        "forensics_lab": true,
+        "training_rooms": 5
+      },
+      "employees": {
+        "total": 345,
+        "security_analysts": 189,
+        "incident_responders": 67,
+        "penetration_testers": 45,
+        "researchers": 23,
+        "administrative": 21
+      },
+      "services": ["24時間SOC", "インシデント対応", "脆弱性診断", "セキュリティ教育"]
+    }
+  ],
+  "data_centers": [
+    {
+      "id": "DC001",
+      "name": "桜花データセンター",
+      "type": "データセンター",
+      "operator": "桜花クラウドサービス",
+      "location": {
+        "city": "桜花市",
+        "district": "データパーク",
+        "address": "桜花市データパークサーバー通り1-1",
+        "area_m2": 25000
+      },
+      "facility_info": {
+        "server_racks": 2000,
+        "power_capacity_mw": 20,
+        "cooling_capacity": "N+1冗長",
+        "tier_level": "Tier III",
+        "security_level": "最高レベル"
+      },
+      "employees": {
+        "total": 156,
+        "data_center_engineers": 89,
+        "security": 34,
+        "network_engineers": 23,
+        "administrative": 10
+      },
+      "clients": 234
+    }
+  ],
+  "telecom_companies": [
+    {
+      "id": "TC001",
+      "name": "桜花通信株式会社",
+      "type": "通信事業者",
+      "specialization": "固定・モバイル通信",
+      "location": {
+        "city": "桜花市",
+        "district": "通信地区",
+        "address": "桜花市通信地区ネットワーク通り1-1"
+      },
+      "services": ["光ファイバー", "5Gモバイル", "企業向け専用線", "IoTソリューション"],
+      "employees": {
+        "total": 1567,
+        "network_engineers": 567,
+        "field_technicians": 456,
+        "customer_service": 345,
+        "sales": 123,
+        "administrative": 76
+      },
+      "subscribers": {
+        "fiber": 450000,
+        "mobile": 890000,
+        "enterprise": 3400
+      }
+    }
+  ],
+  "hardware_manufacturers": [
+    {
+      "id": "HM001",
+      "name": "桜花コンピュータ製造",
+      "type": "ハードウェア製造",
+      "specialization": "サーバー・ストレージ",
+      "location": {
+        "city": "桜川市",
+        "district": "ハイテク工業団地",
+        "address": "桜川市ハイテク工業団地製造通り1-1"
+      },
+      "facility_info": {
+        "factory_area_m2": 45000,
+        "clean_rooms": 8,
+        "production_lines": 6
+      },
+      "employees": {
+        "total": 890,
+        "engineers": 234,
+        "production": 456,
+        "quality_control": 89,
+        "administrative": 111
+      },
+      "annual_production": {
+        "servers": 45000,
+        "storage_units": 67000
+      }
+    }
+  ],
+  "tech_support_companies": [
+    {
+      "id": "TS001",
+      "name": "桜花テクニカルサポート",
+      "type": "技術サポート企業",
+      "specialization": "ヘルプデスク・現地サポート",
+      "location": {
+        "city": "桜花市",
+        "district": "サポート地区",
+        "address": "桜花市サポート地区ヘルプ通り1-1"
+      },
+      "services": ["24時間ヘルプデスク", "オンサイトサポート", "リモートサポート"],
+      "employees": {
+        "total": 456,
+        "support_engineers": 345,
+        "call_center": 89,
+        "administrative": 22
+      },
+      "support_contracts": 1234
+    }
+  ],
+  "research_labs": [
+    {
+      "id": "RL001",
+      "name": "桜花先端技術研究所",
+      "type": "民間研究所",
+      "specialization": "量子コンピューティング・バイオインフォマティクス",
+      "location": {
+        "city": "桜花市",
+        "district": "研究都市",
+        "address": "桜花市研究都市イノベーション通り1-1"
+      },
+      "facility_info": {
+        "laboratories": 12,
+        "clean_rooms": 5,
+        "supercomputer": true
+      },
+      "employees": {
+        "total": 234,
+        "researchers": 156,
+        "technicians": 45,
+        "administrative": 33
+      },
+      "patents_annually": 45,
+      "partnerships": ["東京大学", "理化学研究所", "産総研"]
+    }
+  ],
+  "startups": [
+    {
+      "id": "ST001",
+      "name": "桜花フィンテック",
+      "type": "スタートアップ",
+      "specialization": "ブロックチェーン決済",
+      "location": {
+        "city": "桜花市",
+        "district": "スタートアップ地区",
+        "address": "桜花市スタートアップ地区ベンチャー通り1-1"
+      },
+      "employees": {
+        "total": 45,
+        "engineers": 32,
+        "business": 10,
+        "administrative": 3
+      },
+      "funding_stage": "Series B",
+      "valuation_million_yen": 5000
+    },
+    {
+      "id": "ST002",
+      "name": "サクラヘルステック",
+      "type": "スタートアップ",
+      "specialization": "医療AI診断",
+      "location": {
+        "city": "桜花市",
+        "district": "バイオパーク",
+        "address": "桜花市バイオパークヘルス通り2-2"
+      },
+      "employees": {
+        "total": 34,
+        "researchers": 15,
+        "engineers": 12,
+        "medical_advisors": 4,
+        "administrative": 3
+      }
+    }
+  ],
+  "coworking_spaces": [
+    {
+      "id": "CW001",
+      "name": "桜花イノベーションハブ",
+      "type": "コワーキングスペース",
+      "location": {
+        "city": "桜花市",
+        "district": "起業家地区",
+        "address": "桜花市起業家地区シェア通り1-1"
+      },
+      "facility_info": {
+        "desks": 200,
+        "private_offices": 30,
+        "meeting_rooms": 10,
+        "event_space": true
+      },
+      "employees": {
+        "total": 12,
+        "community_managers": 6,
+        "reception": 4,
+        "administrative": 2
+      },
+      "members": 450
+    }
+  ],
+  "summary": {
+    "total_it_employees": 12345,
+    "software_companies": 156,
+    "it_services": 234,
+    "startups": 89,
+    "research_labs": 23,
+    "technology_coverage": "先進的なIT産業で地域のデジタル化を推進"
+  }
+}

--- a/sakura-ken/data/media-entertainment.json
+++ b/sakura-ken/data/media-entertainment.json
@@ -1,0 +1,585 @@
+{
+  "television_stations": [
+    {
+      "id": "TV001",
+      "name": "桜花テレビ放送",
+      "type": "地方テレビ局",
+      "network": "日本テレビ系列",
+      "location": {
+        "city": "桜花市",
+        "district": "放送センター地区",
+        "address": "桜花市放送センター地区テレビ通り1-1",
+        "coordinates": {"lat": 35.7150, "lng": 139.8500},
+        "area_m2": 25000
+      },
+      "facility_info": {
+        "studios": 6,
+        "control_rooms": 4,
+        "editing_suites": 12,
+        "newsroom": true,
+        "transmission_tower_height_m": 250
+      },
+      "broadcasting": {
+        "coverage_area": "桜県全域",
+        "households_reached": 850000,
+        "programming_hours_daily": 24
+      },
+      "employees": {
+        "total": 456,
+        "announcers": 23,
+        "reporters": 67,
+        "producers": 89,
+        "directors": 45,
+        "camera_operators": 56,
+        "editors": 78,
+        "technical_staff": 65,
+        "administrative": 33,
+        "management": [
+          {
+            "employee_id": "TV001-M001",
+            "name": "社長田放送",
+            "position": "代表取締役社長",
+            "department": "経営企画部",
+            "hire_date": "2018-04-01",
+            "annual_salary": 20000000
+          },
+          {
+            "employee_id": "TV001-M002",
+            "name": "局長田報道",
+            "position": "報道局長",
+            "department": "報道局",
+            "hire_date": "2019-04-01",
+            "annual_salary": 12000000
+          }
+        ]
+      },
+      "programs": {
+        "news": 8,
+        "variety": 12,
+        "drama": 5,
+        "sports": 6,
+        "educational": 4
+      }
+    },
+    {
+      "id": "TV002",
+      "name": "さくらケーブルテレビ",
+      "type": "ケーブルテレビ局",
+      "location": {
+        "city": "桜花市",
+        "district": "通信地区",
+        "address": "桜花市通信地区ケーブル通り2-2"
+      },
+      "services": ["地上波再送信", "CS放送", "インターネット", "電話"],
+      "employees": {
+        "total": 234,
+        "technical_staff": 123,
+        "customer_service": 67,
+        "sales": 23,
+        "administrative": 21
+      },
+      "subscribers": 234000
+    }
+  ],
+  "radio_stations": [
+    {
+      "id": "RD001",
+      "name": "FM桜花",
+      "type": "FMラジオ局",
+      "frequency": "79.5MHz",
+      "location": {
+        "city": "桜花市",
+        "district": "放送センター地区",
+        "address": "桜花市放送センター地区ラジオ通り1-1"
+      },
+      "facility_info": {
+        "studios": 3,
+        "transmission_power_kw": 5,
+        "coverage_radius_km": 80
+      },
+      "employees": {
+        "total": 78,
+        "djs": 12,
+        "producers": 15,
+        "engineers": 20,
+        "sales": 18,
+        "administrative": 13
+      },
+      "programs": {
+        "music": 16,
+        "talk": 8,
+        "news": 6,
+        "local_content": 10
+      },
+      "listeners_daily": 345000
+    },
+    {
+      "id": "RD002",
+      "name": "桜花コミュニティFM",
+      "type": "コミュニティFM",
+      "frequency": "88.8MHz",
+      "location": {
+        "city": "桜花市",
+        "district": "市民地区",
+        "address": "桜花市市民地区コミュニティ通り2-2"
+      },
+      "employees": {
+        "total": 23,
+        "djs": 8,
+        "technical": 5,
+        "volunteers": 10
+      }
+    }
+  ],
+  "newspapers": [
+    {
+      "id": "NP001",
+      "name": "桜花新聞社",
+      "type": "地方新聞社",
+      "location": {
+        "city": "桜花市",
+        "district": "メディア地区",
+        "address": "桜花市メディア地区新聞通り1-1",
+        "area_m2": 15000
+      },
+      "facility_info": {
+        "printing_presses": 4,
+        "newsroom_floors": 3,
+        "distribution_centers": 8
+      },
+      "publication": {
+        "daily_circulation": 450000,
+        "morning_edition": true,
+        "evening_edition": true,
+        "digital_subscribers": 89000
+      },
+      "employees": {
+        "total": 678,
+        "journalists": 234,
+        "editors": 89,
+        "photographers": 45,
+        "printing_staff": 123,
+        "distribution": 156,
+        "administrative": 31,
+        "management": [
+          {
+            "employee_id": "NP001-M001",
+            "name": "社長田新聞",
+            "position": "代表取締役社長",
+            "department": "経営企画部",
+            "hire_date": "2017-04-01",
+            "annual_salary": 18000000
+          }
+        ]
+      },
+      "bureaus": 12
+    },
+    {
+      "id": "NP002",
+      "name": "桜川タイムズ",
+      "type": "地域新聞社",
+      "location": {
+        "city": "桜川市",
+        "district": "中央地区",
+        "address": "桜川市中央地区地域新聞通り1-1"
+      },
+      "employees": {
+        "total": 56,
+        "journalists": 23,
+        "editors": 12,
+        "administrative": 21
+      },
+      "circulation": 78000
+    }
+  ],
+  "publishing_companies": [
+    {
+      "id": "PB001",
+      "name": "桜花出版",
+      "type": "総合出版社",
+      "specialization": "書籍・雑誌",
+      "location": {
+        "city": "桜花市",
+        "district": "出版地区",
+        "address": "桜花市出版地区書籍通り1-1"
+      },
+      "publications": {
+        "books_annually": 234,
+        "magazines": 12,
+        "manga": 23
+      },
+      "employees": {
+        "total": 234,
+        "editors": 89,
+        "designers": 45,
+        "marketing": 34,
+        "sales": 45,
+        "administrative": 21
+      }
+    },
+    {
+      "id": "PB002",
+      "name": "さくらコミックス",
+      "type": "漫画出版社",
+      "location": {
+        "city": "桜花市",
+        "district": "クリエイティブ地区",
+        "address": "桜花市クリエイティブ地区漫画通り2-2"
+      },
+      "employees": {
+        "total": 78,
+        "editors": 45,
+        "designers": 20,
+        "administrative": 13
+      },
+      "manga_titles": 156
+    }
+  ],
+  "movie_theaters": [
+    {
+      "id": "MT001",
+      "name": "桜花シネマコンプレックス",
+      "type": "シネコン",
+      "chain": "TOHOシネマズ",
+      "location": {
+        "city": "桜花市",
+        "district": "エンタメ地区",
+        "address": "桜花市エンタメ地区映画通り1-1"
+      },
+      "facility_info": {
+        "screens": 12,
+        "total_seats": 2345,
+        "imax": true,
+        "4dx": true,
+        "dolby_atmos": true
+      },
+      "employees": {
+        "total": 89,
+        "projectionists": 12,
+        "ticket_staff": 34,
+        "concession": 23,
+        "cleaning": 15,
+        "administrative": 5
+      },
+      "annual_visitors": 890000
+    },
+    {
+      "id": "MT002",
+      "name": "桜花アートシアター",
+      "type": "ミニシアター",
+      "specialization": "アート映画",
+      "location": {
+        "city": "桜花市",
+        "district": "文化地区",
+        "address": "桜花市文化地区芸術通り2-2"
+      },
+      "facility_info": {
+        "screens": 2,
+        "total_seats": 180
+      },
+      "employees": {
+        "total": 12,
+        "staff": 10,
+        "administrative": 2
+      }
+    }
+  ],
+  "theaters": [
+    {
+      "id": "TH001",
+      "name": "桜花市民劇場",
+      "type": "公立劇場",
+      "location": {
+        "city": "桜花市",
+        "district": "文化地区",
+        "address": "桜花市文化地区劇場通り1-1"
+      },
+      "facility_info": {
+        "main_hall_seats": 1200,
+        "small_hall_seats": 300,
+        "rehearsal_rooms": 5,
+        "dressing_rooms": 12
+      },
+      "employees": {
+        "total": 56,
+        "technical_staff": 23,
+        "stage_managers": 8,
+        "box_office": 10,
+        "administrative": 15
+      },
+      "annual_performances": 234
+    },
+    {
+      "id": "TH002",
+      "name": "さくら歌舞伎座",
+      "type": "歌舞伎劇場",
+      "location": {
+        "city": "桜花市",
+        "district": "伝統芸能地区",
+        "address": "桜花市伝統芸能地区歌舞伎通り1-1"
+      },
+      "employees": {
+        "total": 45,
+        "technical": 20,
+        "customer_service": 15,
+        "administrative": 10
+      }
+    }
+  ],
+  "concert_halls": [
+    {
+      "id": "CH001",
+      "name": "桜花音楽ホール",
+      "type": "コンサートホール",
+      "location": {
+        "city": "桜花市",
+        "district": "音楽地区",
+        "address": "桜花市音楽地区交響通り1-1"
+      },
+      "facility_info": {
+        "main_hall_seats": 2000,
+        "chamber_hall_seats": 500,
+        "acoustics": "世界クラス",
+        "pipe_organ": true
+      },
+      "employees": {
+        "total": 78,
+        "technical_staff": 34,
+        "stage_crew": 20,
+        "box_office": 12,
+        "administrative": 12
+      },
+      "annual_concerts": 345
+    }
+  ],
+  "live_music_venues": [
+    {
+      "id": "LV001",
+      "name": "桜花ライブハウス",
+      "type": "ライブハウス",
+      "capacity": 800,
+      "location": {
+        "city": "桜花市",
+        "district": "音楽地区",
+        "address": "桜花市音楽地区ライブ通り1-1"
+      },
+      "employees": {
+        "total": 23,
+        "sound_engineers": 8,
+        "security": 8,
+        "bar_staff": 5,
+        "administrative": 2
+      },
+      "annual_shows": 234
+    }
+  ],
+  "museums": [
+    {
+      "id": "MU001",
+      "name": "桜県立美術館",
+      "type": "美術館",
+      "location": {
+        "city": "桜花市",
+        "district": "文化地区",
+        "address": "桜花市文化地区美術館通り1-1"
+      },
+      "facility_info": {
+        "exhibition_spaces": 8,
+        "permanent_collection": 12000,
+        "storage_area_m2": 3000,
+        "restoration_lab": true
+      },
+      "employees": {
+        "total": 89,
+        "curators": 23,
+        "conservators": 12,
+        "educators": 15,
+        "security": 20,
+        "administrative": 19
+      },
+      "annual_visitors": 450000
+    },
+    {
+      "id": "MU002",
+      "name": "桜花科学博物館",
+      "type": "科学博物館",
+      "location": {
+        "city": "桜花市",
+        "district": "教育地区",
+        "address": "桜花市教育地区科学通り2-2"
+      },
+      "employees": {
+        "total": 67,
+        "researchers": 20,
+        "educators": 23,
+        "technical": 15,
+        "administrative": 9
+      },
+      "features": ["プラネタリウム", "体験型展示", "実験室"]
+    }
+  ],
+  "amusement_parks": [
+    {
+      "id": "AP001",
+      "name": "桜花ランド",
+      "type": "遊園地",
+      "location": {
+        "city": "桜花市",
+        "district": "レジャー地区",
+        "address": "桜花市レジャー地区遊園地通り1-1",
+        "area_m2": 150000
+      },
+      "attractions": {
+        "roller_coasters": 5,
+        "water_rides": 3,
+        "family_rides": 20,
+        "shows": 4
+      },
+      "employees": {
+        "total": 456,
+        "ride_operators": 234,
+        "entertainers": 45,
+        "maintenance": 89,
+        "food_service": 56,
+        "administrative": 32
+      },
+      "annual_visitors": 1200000
+    }
+  ],
+  "sports_facilities": [
+    {
+      "id": "SF001",
+      "name": "桜花スタジアム",
+      "type": "総合スポーツ施設",
+      "location": {
+        "city": "桜花市",
+        "district": "スポーツ地区",
+        "address": "桜花市スポーツ地区競技場通り1-1"
+      },
+      "facility_info": {
+        "main_stadium_capacity": 45000,
+        "athletics_track": true,
+        "indoor_arena_capacity": 8000,
+        "swimming_pools": 3
+      },
+      "employees": {
+        "total": 234,
+        "facility_management": 89,
+        "security": 67,
+        "maintenance": 45,
+        "administrative": 33
+      }
+    }
+  ],
+  "game_centers": [
+    {
+      "id": "GC001",
+      "name": "桜花ゲームセンター",
+      "type": "アミューズメント施設",
+      "chain": "セガ",
+      "location": {
+        "city": "桜花市",
+        "district": "繁華街",
+        "address": "桜花市繁華街ゲーム通り1-1"
+      },
+      "facility_info": {
+        "floors": 4,
+        "game_machines": 350,
+        "vr_zones": 2,
+        "prize_corners": 3
+      },
+      "employees": {
+        "total": 34,
+        "floor_staff": 20,
+        "maintenance": 8,
+        "administrative": 6
+      }
+    }
+  ],
+  "karaoke_boxes": [
+    {
+      "id": "KB001",
+      "name": "カラオケ桜花",
+      "type": "カラオケボックス",
+      "chain": "ビッグエコー",
+      "location": {
+        "city": "桜花市",
+        "district": "繁華街",
+        "address": "桜花市繁華街歌通り1-1"
+      },
+      "facility_info": {
+        "rooms": 45,
+        "party_rooms": 5,
+        "kids_rooms": 3
+      },
+      "employees": {
+        "total": 23,
+        "reception": 8,
+        "service_staff": 10,
+        "kitchen": 3,
+        "administrative": 2
+      }
+    }
+  ],
+  "production_companies": [
+    {
+      "id": "PC001",
+      "name": "桜花映像制作",
+      "type": "映像制作会社",
+      "specialization": "CM・ドラマ・映画",
+      "location": {
+        "city": "桜花市",
+        "district": "制作地区",
+        "address": "桜花市制作地区プロダクション通り1-1"
+      },
+      "facility_info": {
+        "studios": 3,
+        "editing_suites": 8,
+        "color_grading": true,
+        "sound_studios": 2
+      },
+      "employees": {
+        "total": 123,
+        "producers": 23,
+        "directors": 15,
+        "camera_operators": 34,
+        "editors": 28,
+        "sound_engineers": 12,
+        "administrative": 11
+      }
+    }
+  ],
+  "talent_agencies": [
+    {
+      "id": "TA001",
+      "name": "桜花芸能事務所",
+      "type": "芸能事務所",
+      "location": {
+        "city": "桜花市",
+        "district": "芸能地区",
+        "address": "桜花市芸能地区タレント通り1-1"
+      },
+      "talent": {
+        "actors": 89,
+        "musicians": 45,
+        "comedians": 23,
+        "models": 67
+      },
+      "employees": {
+        "total": 67,
+        "managers": 34,
+        "pr_staff": 15,
+        "administrative": 18
+      }
+    }
+  ],
+  "summary": {
+    "total_media_entertainment_employees": 5678,
+    "broadcasting": 768,
+    "print_media": 968,
+    "theaters_venues": 890,
+    "amusement_facilities": 1567,
+    "production_agencies": 1485,
+    "entertainment_coverage": "多様なメディア・エンターテインメントで文化生活を豊かに"
+  }
+}

--- a/sakura-ken/data/professional-services.json
+++ b/sakura-ken/data/professional-services.json
@@ -1,0 +1,521 @@
+{
+  "law_firms": [
+    {
+      "id": "LF001",
+      "name": "桜花総合法律事務所",
+      "type": "総合法律事務所",
+      "specialization": "企業法務・M&A・知的財産",
+      "location": {
+        "city": "桜花市",
+        "district": "司法地区",
+        "address": "桜花市司法地区法律通り1-1",
+        "coordinates": {"lat": 35.7110, "lng": 139.8470},
+        "area_m2": 3500
+      },
+      "facility_info": {
+        "floors": 5,
+        "conference_rooms": 12,
+        "library": true,
+        "mock_courtroom": true
+      },
+      "practice_areas": [
+        "企業法務", "M&A", "知的財産", "労働法", "不動産",
+        "金融法務", "国際取引", "訴訟・紛争解決"
+      ],
+      "employees": {
+        "total": 234,
+        "partners": 23,
+        "associates": 67,
+        "paralegals": 89,
+        "administrative": 55,
+        "management": [
+          {
+            "employee_id": "LF001-M001",
+            "name": "代表田弁護",
+            "position": "代表弁護士",
+            "specialization": "M&A・企業再編",
+            "bar_admission": "1995-04-01",
+            "hire_date": "2010-04-01",
+            "annual_salary": 50000000
+          },
+          {
+            "employee_id": "LF001-M002",
+            "name": "管理田法務",
+            "position": "マネージングパートナー",
+            "specialization": "知的財産法",
+            "bar_admission": "1998-04-01",
+            "hire_date": "2012-04-01",
+            "annual_salary": 40000000
+          }
+        ],
+        "sample_lawyers": [
+          {
+            "employee_id": "LF001-L001",
+            "name": "弁護士田企業",
+            "position": "パートナー弁護士",
+            "specialization": "企業法務",
+            "bar_admission": "2005-04-01",
+            "annual_salary": 25000000
+          },
+          {
+            "employee_id": "LF001-L002",
+            "name": "弁護士田知財",
+            "position": "シニアアソシエイト",
+            "specialization": "特許・商標",
+            "bar_admission": "2015-04-01",
+            "annual_salary": 12000000
+          }
+        ]
+      },
+      "clients": {
+        "corporate": 450,
+        "individual": 890,
+        "government": 23
+      }
+    },
+    {
+      "id": "LF002",
+      "name": "さくら法律事務所",
+      "type": "中規模法律事務所",
+      "specialization": "民事・家事・刑事",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区弁護士通り2-2"
+      },
+      "employees": {
+        "total": 45,
+        "partners": 5,
+        "associates": 12,
+        "paralegals": 18,
+        "administrative": 10
+      }
+    },
+    {
+      "id": "LF003",
+      "name": "桜川法律事務所",
+      "type": "地域密着型法律事務所",
+      "specialization": "交通事故・債務整理",
+      "location": {
+        "city": "桜川市",
+        "district": "中央地区",
+        "address": "桜川市中央地区法律相談通り1-1"
+      },
+      "employees": {
+        "total": 23,
+        "lawyers": 8,
+        "paralegals": 10,
+        "administrative": 5
+      }
+    }
+  ],
+  "patent_offices": [
+    {
+      "id": "PO001",
+      "name": "桜花国際特許事務所",
+      "type": "特許事務所",
+      "specialization": "特許・意匠・商標",
+      "location": {
+        "city": "桜花市",
+        "district": "知財地区",
+        "address": "桜花市知財地区特許通り1-1"
+      },
+      "employees": {
+        "total": 89,
+        "patent_attorneys": 34,
+        "technical_staff": 23,
+        "translators": 12,
+        "administrative": 20,
+        "management": [
+          {
+            "employee_id": "PO001-M001",
+            "name": "所長田特許",
+            "position": "所長弁理士",
+            "specialization": "電子・ソフトウェア特許",
+            "registration": "弁理士登録第12345号",
+            "hire_date": "2008-04-01",
+            "annual_salary": 20000000
+          }
+        ]
+      },
+      "services": {
+        "patent_applications": true,
+        "pct_applications": true,
+        "trademark_registration": true,
+        "ip_litigation": true
+      },
+      "annual_filings": 1234
+    }
+  ],
+  "judicial_scrivener_offices": [
+    {
+      "id": "JS001",
+      "name": "桜花司法書士事務所",
+      "type": "司法書士事務所",
+      "specialization": "不動産登記・商業登記",
+      "location": {
+        "city": "桜花市",
+        "district": "登記地区",
+        "address": "桜花市登記地区司法書士通り1-1"
+      },
+      "employees": {
+        "total": 34,
+        "judicial_scriveners": 12,
+        "assistants": 15,
+        "administrative": 7
+      },
+      "services": {
+        "real_estate_registration": true,
+        "commercial_registration": true,
+        "inheritance_procedures": true,
+        "debt_consolidation": true
+      }
+    }
+  ],
+  "administrative_scrivener_offices": [
+    {
+      "id": "AS001",
+      "name": "桜花行政書士事務所",
+      "type": "行政書士事務所",
+      "specialization": "許認可・在留資格",
+      "location": {
+        "city": "桜花市",
+        "district": "行政地区",
+        "address": "桜花市行政地区許可通り1-1"
+      },
+      "employees": {
+        "total": 23,
+        "administrative_scriveners": 8,
+        "assistants": 10,
+        "administrative": 5
+      },
+      "services": {
+        "business_permits": true,
+        "visa_applications": true,
+        "incorporation": true,
+        "inheritance_division": true
+      }
+    }
+  ],
+  "consulting_firms": [
+    {
+      "id": "CF001",
+      "name": "桜花経営コンサルティング",
+      "type": "経営コンサルティング",
+      "specialization": "戦略・組織・デジタル変革",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街戦略通り1-1",
+        "area_m2": 2800
+      },
+      "practice_areas": [
+        "経営戦略", "組織変革", "デジタルトランスフォーメーション",
+        "M&A アドバイザリー", "業務改善", "人事戦略"
+      ],
+      "employees": {
+        "total": 345,
+        "partners": 34,
+        "managers": 67,
+        "consultants": 156,
+        "analysts": 56,
+        "administrative": 32,
+        "management": [
+          {
+            "employee_id": "CF001-M001",
+            "name": "代表田戦略",
+            "position": "代表パートナー",
+            "specialization": "企業戦略",
+            "hire_date": "2015-04-01",
+            "annual_salary": 35000000
+          }
+        ]
+      },
+      "clients": {
+        "fortune500": 23,
+        "large_domestic": 89,
+        "sme": 234,
+        "government": 12
+      }
+    },
+    {
+      "id": "CF002",
+      "name": "マッキンゼー・アンド・カンパニー桜花オフィス",
+      "type": "外資系コンサルティング",
+      "location": {
+        "city": "桜花市",
+        "district": "国際ビジネス街",
+        "address": "桜花市国際ビジネス街グローバル通り2-2"
+      },
+      "employees": {
+        "total": 123,
+        "partners": 8,
+        "managers": 23,
+        "consultants": 56,
+        "analysts": 36
+      }
+    },
+    {
+      "id": "CF003",
+      "name": "桜花人事コンサルティング",
+      "type": "人事コンサルティング",
+      "specialization": "人事制度・組織開発",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街人材通り3-3"
+      },
+      "employees": {
+        "total": 67,
+        "consultants": 45,
+        "researchers": 12,
+        "administrative": 10
+      }
+    }
+  ],
+  "marketing_agencies": [
+    {
+      "id": "MA001",
+      "name": "桜花広告代理店",
+      "type": "総合広告代理店",
+      "location": {
+        "city": "桜花市",
+        "district": "メディア地区",
+        "address": "桜花市メディア地区広告通り1-1"
+      },
+      "services": [
+        "テレビCM制作", "デジタルマーケティング", "イベントプロモーション",
+        "ブランディング", "PR戦略"
+      ],
+      "employees": {
+        "total": 456,
+        "account_executives": 123,
+        "creative_directors": 45,
+        "copywriters": 67,
+        "designers": 89,
+        "digital_marketers": 78,
+        "administrative": 54
+      },
+      "annual_billings_million_yen": 12000
+    },
+    {
+      "id": "MA002",
+      "name": "桜デジタルエージェンシー",
+      "type": "デジタル専門広告代理店",
+      "location": {
+        "city": "桜花市",
+        "district": "デジタル地区",
+        "address": "桜花市デジタル地区オンライン通り2-2"
+      },
+      "employees": {
+        "total": 89,
+        "digital_strategists": 34,
+        "performance_marketers": 23,
+        "data_analysts": 20,
+        "administrative": 12
+      }
+    }
+  ],
+  "pr_firms": [
+    {
+      "id": "PR001",
+      "name": "桜花パブリックリレーションズ",
+      "type": "PR会社",
+      "specialization": "企業広報・危機管理",
+      "location": {
+        "city": "桜花市",
+        "district": "メディア地区",
+        "address": "桜花市メディア地区PR通り1-1"
+      },
+      "employees": {
+        "total": 78,
+        "pr_consultants": 45,
+        "media_relations": 23,
+        "administrative": 10
+      },
+      "clients": 156
+    }
+  ],
+  "design_studios": [
+    {
+      "id": "DS001",
+      "name": "桜花デザインスタジオ",
+      "type": "デザイン事務所",
+      "specialization": "ブランドデザイン・UI/UX",
+      "location": {
+        "city": "桜花市",
+        "district": "クリエイティブ地区",
+        "address": "桜花市クリエイティブ地区デザイン通り1-1"
+      },
+      "employees": {
+        "total": 56,
+        "creative_directors": 5,
+        "designers": 34,
+        "ux_researchers": 12,
+        "administrative": 5
+      }
+    }
+  ],
+  "architecture_firms": [
+    {
+      "id": "AF001",
+      "name": "桜花建築設計事務所",
+      "type": "建築設計事務所",
+      "specialization": "商業施設・公共建築",
+      "location": {
+        "city": "桜花市",
+        "district": "建築地区",
+        "address": "桜花市建築地区設計通り1-1"
+      },
+      "employees": {
+        "total": 123,
+        "architects": 67,
+        "structural_engineers": 23,
+        "cad_operators": 20,
+        "administrative": 13,
+        "management": [
+          {
+            "employee_id": "AF001-M001",
+            "name": "所長田建築",
+            "position": "代表建築士",
+            "license": "一級建築士第123456号",
+            "hire_date": "2010-04-01",
+            "annual_salary": 18000000
+          }
+        ]
+      },
+      "projects_annually": 45,
+      "awards": 12
+    }
+  ],
+  "translation_companies": [
+    {
+      "id": "TR001",
+      "name": "桜花翻訳センター",
+      "type": "翻訳会社",
+      "specialization": "技術翻訳・ビジネス翻訳",
+      "location": {
+        "city": "桜花市",
+        "district": "国際地区",
+        "address": "桜花市国際地区翻訳通り1-1"
+      },
+      "languages": ["英語", "中国語", "韓国語", "スペイン語", "フランス語"],
+      "employees": {
+        "total": 89,
+        "translators": 56,
+        "interpreters": 23,
+        "project_managers": 10
+      },
+      "annual_projects": 3456
+    }
+  ],
+  "recruitment_agencies": [
+    {
+      "id": "RA001",
+      "name": "桜花人材紹介",
+      "type": "人材紹介会社",
+      "specialization": "エグゼクティブサーチ",
+      "location": {
+        "city": "桜花市",
+        "district": "ビジネス街",
+        "address": "桜花市ビジネス街採用通り1-1"
+      },
+      "employees": {
+        "total": 156,
+        "recruiters": 89,
+        "researchers": 34,
+        "career_consultants": 23,
+        "administrative": 10
+      },
+      "placements_annually": 2345
+    },
+    {
+      "id": "RA002",
+      "name": "桜花スタッフサービス",
+      "type": "人材派遣会社",
+      "location": {
+        "city": "桜花市",
+        "district": "雇用地区",
+        "address": "桜花市雇用地区派遣通り2-2"
+      },
+      "employees": {
+        "total": 234,
+        "coordinators": 123,
+        "sales": 67,
+        "administrative": 44
+      },
+      "registered_staff": 8900
+    }
+  ],
+  "real_estate_agencies": [
+    {
+      "id": "RE001",
+      "name": "桜花不動産",
+      "type": "総合不動産会社",
+      "location": {
+        "city": "桜花市",
+        "district": "不動産街",
+        "address": "桜花市不動産街物件通り1-1"
+      },
+      "services": ["売買仲介", "賃貸仲介", "不動産管理", "開発事業"],
+      "employees": {
+        "total": 234,
+        "sales_agents": 123,
+        "property_managers": 56,
+        "appraisers": 23,
+        "administrative": 32
+      },
+      "managed_properties": 4567
+    }
+  ],
+  "insurance_brokers": [
+    {
+      "id": "IB001",
+      "name": "桜花保険代理店",
+      "type": "総合保険代理店",
+      "location": {
+        "city": "桜花市",
+        "district": "保険街",
+        "address": "桜花市保険街代理店通り1-1"
+      },
+      "employees": {
+        "total": 78,
+        "insurance_agents": 56,
+        "claims_support": 12,
+        "administrative": 10
+      },
+      "contracts": 12000
+    }
+  ],
+  "event_planning": [
+    {
+      "id": "EP001",
+      "name": "桜花イベントプランニング",
+      "type": "イベント企画会社",
+      "specialization": "企業イベント・展示会",
+      "location": {
+        "city": "桜花市",
+        "district": "イベント地区",
+        "address": "桜花市イベント地区企画通り1-1"
+      },
+      "employees": {
+        "total": 67,
+        "event_planners": 34,
+        "producers": 12,
+        "coordinators": 15,
+        "administrative": 6
+      },
+      "annual_events": 234
+    }
+  ],
+  "summary": {
+    "total_professional_employees": 4567,
+    "law_related": 456,
+    "consulting": 789,
+    "marketing_pr": 890,
+    "architecture_design": 234,
+    "hr_recruitment": 567,
+    "other_professional": 1631,
+    "professional_coverage": "高度な専門サービスでビジネスを支援"
+  }
+}

--- a/sakura-ken/data/research-development.json
+++ b/sakura-ken/data/research-development.json
@@ -1,0 +1,477 @@
+{
+  "corporate_rd_centers": [
+    {
+      "id": "RD001",
+      "name": "桜花電機中央研究所",
+      "type": "企業研究所",
+      "company": "桜花電機株式会社",
+      "specialization": "電子デバイス・半導体",
+      "location": {
+        "city": "桜花市",
+        "district": "研究開発地区",
+        "address": "桜花市研究開発地区イノベーション1-1",
+        "coordinates": {"lat": 35.7220, "lng": 139.8570},
+        "area_m2": 65000
+      },
+      "facility_info": {
+        "buildings": 5,
+        "laboratories": 45,
+        "clean_rooms": 12,
+        "testing_facilities": 20,
+        "pilot_production_lines": 3,
+        "conference_center": true
+      },
+      "research_areas": [
+        "次世代半導体", "パワーデバイス", "センサー技術",
+        "量子デバイス", "AI チップ", "通信モジュール"
+      ],
+      "employees": {
+        "total": 890,
+        "researchers": 567,
+        "engineers": 234,
+        "technicians": 56,
+        "administrative": 33,
+        "management": [
+          {
+            "employee_id": "RD001-M001",
+            "name": "所長田研究",
+            "position": "研究所長",
+            "department": "研究統括部",
+            "specialization": "半導体物理学",
+            "phd": "東京大学",
+            "hire_date": "2018-04-01",
+            "annual_salary": 25000000
+          },
+          {
+            "employee_id": "RD001-M002",
+            "name": "副所長田開発",
+            "position": "副所長",
+            "department": "開発統括部",
+            "specialization": "材料工学",
+            "phd": "京都大学",
+            "hire_date": "2019-04-01",
+            "annual_salary": 20000000
+          }
+        ],
+        "sample_researchers": [
+          {
+            "employee_id": "RD001-R001",
+            "name": "研究員田量子",
+            "position": "主任研究員",
+            "department": "量子デバイス研究部",
+            "specialization": "量子物理学",
+            "phd": "東北大学",
+            "hire_date": "2015-04-01",
+            "annual_salary": 12000000
+          }
+        ]
+      },
+      "equipment": {
+        "electron_microscopes": 8,
+        "x_ray_diffractometers": 5,
+        "mass_spectrometers": 6,
+        "clean_room_class": 10
+      },
+      "achievements": {
+        "patents_annually": 234,
+        "papers_annually": 156,
+        "products_commercialized": 23
+      }
+    },
+    {
+      "id": "RD002",
+      "name": "桜製薬研究開発センター",
+      "type": "製薬研究所",
+      "company": "桜製薬株式会社",
+      "specialization": "創薬・バイオ医薬品",
+      "location": {
+        "city": "桜花市",
+        "district": "バイオパーク",
+        "address": "桜花市バイオパーク創薬通り2-2"
+      },
+      "facility_info": {
+        "laboratories": 38,
+        "animal_facility": true,
+        "cell_culture_rooms": 15,
+        "biosafety_level": "BSL-3"
+      },
+      "research_areas": [
+        "がん治療薬", "免疫療法", "遺伝子治療", "再生医療", "感染症薬"
+      ],
+      "employees": {
+        "total": 678,
+        "researchers": 456,
+        "lab_technicians": 156,
+        "clinical_trial_staff": 45,
+        "administrative": 21
+      },
+      "pipeline_drugs": 34
+    },
+    {
+      "id": "RD003",
+      "name": "桜自動車技術センター",
+      "type": "自動車研究所",
+      "company": "桜自動車工業",
+      "specialization": "電動化・自動運転",
+      "location": {
+        "city": "桜川市",
+        "district": "モビリティ地区",
+        "address": "桜川市モビリティ地区テストコース1-1"
+      },
+      "facility_info": {
+        "test_tracks": 3,
+        "wind_tunnel": true,
+        "crash_test_facility": true,
+        "battery_lab": true
+      },
+      "employees": {
+        "total": 567,
+        "engineers": 345,
+        "test_drivers": 45,
+        "technicians": 134,
+        "administrative": 43
+      }
+    }
+  ],
+  "government_research_institutes": [
+    {
+      "id": "GR001",
+      "name": "桜県産業技術総合研究所",
+      "type": "公設研究機関",
+      "jurisdiction": "桜県",
+      "specialization": "産業技術全般",
+      "location": {
+        "city": "桜花市",
+        "district": "産業研究地区",
+        "address": "桜花市産業研究地区技術通り1-1"
+      },
+      "research_divisions": [
+        "材料技術部", "機械電子部", "化学技術部", "食品バイオ部", "環境技術部"
+      ],
+      "employees": {
+        "total": 234,
+        "researchers": 156,
+        "technicians": 45,
+        "administrative": 33,
+        "management": [
+          {
+            "employee_id": "GR001-M001",
+            "name": "所長田公設",
+            "position": "所長",
+            "specialization": "材料工学",
+            "hire_date": "2017-04-01",
+            "annual_salary": 15000000
+          }
+        ]
+      },
+      "services": {
+        "technical_consultation": true,
+        "testing_analysis": true,
+        "joint_research": true,
+        "equipment_rental": true
+      },
+      "annual_support_cases": 1234
+    },
+    {
+      "id": "GR002",
+      "name": "桜県農業研究センター",
+      "type": "農業研究機関",
+      "jurisdiction": "桜県",
+      "location": {
+        "city": "桜川市",
+        "district": "農業地区",
+        "address": "桜川市農業地区研究農場1-1"
+      },
+      "facility_info": {
+        "experimental_fields_ha": 50,
+        "greenhouses": 20,
+        "laboratories": 12
+      },
+      "research_areas": [
+        "品種改良", "栽培技術", "病害虫防除", "スマート農業"
+      ],
+      "employees": {
+        "total": 123,
+        "researchers": 67,
+        "field_technicians": 34,
+        "administrative": 22
+      }
+    }
+  ],
+  "university_research_centers": [
+    {
+      "id": "UR001",
+      "name": "桜花大学先端科学研究センター",
+      "type": "大学研究施設",
+      "university": "桜花大学",
+      "specialization": "基礎科学・応用研究",
+      "location": {
+        "city": "桜花市",
+        "district": "大学町",
+        "address": "桜花市大学町学術研究1-1"
+      },
+      "research_groups": 45,
+      "employees": {
+        "total": 345,
+        "professors": 56,
+        "researchers": 123,
+        "graduate_students": 134,
+        "technicians": 32
+      },
+      "major_projects": [
+        "量子コンピューティング", "再生可能エネルギー", "AIロボティクス"
+      ],
+      "annual_research_budget_million_yen": 2345
+    },
+    {
+      "id": "UR002",
+      "name": "桜花医科大学附属研究所",
+      "type": "医学研究施設",
+      "university": "桜花医科大学",
+      "location": {
+        "city": "桜花市",
+        "district": "医学部地区",
+        "address": "桜花市医学部地区研究棟2-2"
+      },
+      "research_areas": [
+        "がん研究", "再生医療", "脳科学", "感染症"
+      ],
+      "employees": {
+        "total": 234,
+        "faculty": 45,
+        "postdocs": 67,
+        "technicians": 89,
+        "administrative": 33
+      }
+    }
+  ],
+  "private_research_labs": [
+    {
+      "id": "PR001",
+      "name": "桜花バイオテクノロジー研究所",
+      "type": "民間研究所",
+      "specialization": "遺伝子工学・創薬",
+      "location": {
+        "city": "桜花市",
+        "district": "バイオパーク",
+        "address": "桜花市バイオパーク遺伝子通り1-1"
+      },
+      "facility_info": {
+        "biosafety_level": "BSL-2",
+        "sequencing_center": true,
+        "protein_analysis": true
+      },
+      "employees": {
+        "total": 156,
+        "researchers": 89,
+        "bioinformaticians": 34,
+        "lab_technicians": 23,
+        "administrative": 10
+      },
+      "partnerships": ["理化学研究所", "産総研", "東京大学"]
+    },
+    {
+      "id": "PR002",
+      "name": "桜AIラボラトリー",
+      "type": "AI研究所",
+      "specialization": "深層学習・自然言語処理",
+      "location": {
+        "city": "桜花市",
+        "district": "AIバレー",
+        "address": "桜花市AIバレー機械学習通り2-2"
+      },
+      "infrastructure": {
+        "gpu_clusters": 5,
+        "total_computing_power_pflops": 2.5
+      },
+      "employees": {
+        "total": 89,
+        "ai_researchers": 56,
+        "data_scientists": 23,
+        "engineers": 10
+      }
+    }
+  ],
+  "incubation_facilities": [
+    {
+      "id": "IF001",
+      "name": "桜花イノベーションセンター",
+      "type": "インキュベーション施設",
+      "operator": "桜県",
+      "location": {
+        "city": "桜花市",
+        "district": "起業支援地区",
+        "address": "桜花市起業支援地区スタートアップ通り1-1"
+      },
+      "facility_info": {
+        "office_spaces": 50,
+        "wet_labs": 12,
+        "shared_equipment_rooms": 8,
+        "conference_rooms": 10
+      },
+      "tenant_companies": 34,
+      "employees": {
+        "total": 23,
+        "incubation_managers": 8,
+        "technical_advisors": 10,
+        "administrative": 5
+      },
+      "success_stories": 45
+    }
+  ],
+  "testing_facilities": [
+    {
+      "id": "TF001",
+      "name": "桜花試験評価センター",
+      "type": "試験認証機関",
+      "specialization": "電気製品・EMC試験",
+      "location": {
+        "city": "桜花市",
+        "district": "品質管理地区",
+        "address": "桜花市品質管理地区試験通り1-1"
+      },
+      "facility_info": {
+        "anechoic_chambers": 3,
+        "environmental_test_chambers": 12,
+        "safety_test_labs": 8
+      },
+      "certifications": ["ISO/IEC 17025", "JIS認定"],
+      "employees": {
+        "total": 78,
+        "test_engineers": 45,
+        "quality_inspectors": 23,
+        "administrative": 10
+      },
+      "annual_tests": 4567
+    }
+  ],
+  "think_tanks": [
+    {
+      "id": "TT001",
+      "name": "桜花総合研究所",
+      "type": "シンクタンク",
+      "specialization": "経済・社会政策",
+      "location": {
+        "city": "桜花市",
+        "district": "政策研究地区",
+        "address": "桜花市政策研究地区分析通り1-1"
+      },
+      "research_areas": [
+        "地域経済", "産業政策", "環境政策", "社会保障", "都市計画"
+      ],
+      "employees": {
+        "total": 89,
+        "researchers": 56,
+        "economists": 23,
+        "data_analysts": 10
+      },
+      "annual_reports": 45,
+      "policy_recommendations": 123
+    }
+  ],
+  "specialized_labs": [
+    {
+      "id": "SL001",
+      "name": "桜花ナノテクノロジーセンター",
+      "type": "専門研究施設",
+      "specialization": "ナノ材料・ナノデバイス",
+      "location": {
+        "city": "桜花市",
+        "district": "先端技術地区",
+        "address": "桜花市先端技術地区ナノ通り1-1"
+      },
+      "equipment": {
+        "electron_beam_lithography": 2,
+        "atomic_force_microscopes": 5,
+        "clean_room_class": 100
+      },
+      "employees": {
+        "total": 67,
+        "researchers": 45,
+        "technicians": 15,
+        "administrative": 7
+      }
+    },
+    {
+      "id": "SL002",
+      "name": "桜花環境分析センター",
+      "type": "環境研究施設",
+      "specialization": "環境モニタリング・分析",
+      "location": {
+        "city": "桜花市",
+        "district": "環境地区",
+        "address": "桜花市環境地区グリーン通り2-2"
+      },
+      "services": [
+        "大気質分析", "水質検査", "土壌分析", "騒音測定"
+      ],
+      "employees": {
+        "total": 56,
+        "environmental_scientists": 34,
+        "lab_technicians": 15,
+        "administrative": 7
+      }
+    }
+  ],
+  "collaborative_spaces": [
+    {
+      "id": "CS001",
+      "name": "桜花オープンイノベーションラボ",
+      "type": "共創施設",
+      "location": {
+        "city": "桜花市",
+        "district": "コラボ地区",
+        "address": "桜花市コラボ地区共創通り1-1"
+      },
+      "facility_info": {
+        "project_spaces": 20,
+        "fab_lab": true,
+        "prototype_workshop": true,
+        "vr_studio": true
+      },
+      "member_organizations": 67,
+      "employees": {
+        "total": 34,
+        "facilitators": 12,
+        "technical_support": 15,
+        "administrative": 7
+      }
+    }
+  ],
+  "clinical_research": [
+    {
+      "id": "CR001",
+      "name": "桜花臨床研究センター",
+      "type": "臨床研究施設",
+      "affiliated_hospital": "桜県立中央病院",
+      "location": {
+        "city": "桜花市",
+        "district": "医療センター地区",
+        "address": "桜花市医療センター地区臨床研究1-1"
+      },
+      "trial_capabilities": {
+        "phase_1_beds": 20,
+        "phase_2_3_capacity": 200,
+        "outpatient_facilities": true
+      },
+      "employees": {
+        "total": 123,
+        "principal_investigators": 23,
+        "clinical_research_coordinators": 45,
+        "data_managers": 34,
+        "administrative": 21
+      },
+      "active_trials": 67
+    }
+  ],
+  "summary": {
+    "total_rd_employees": 5678,
+    "corporate_rd": 2345,
+    "government_research": 567,
+    "university_research": 890,
+    "private_labs": 678,
+    "support_facilities": 1198,
+    "annual_patents": 1234,
+    "rd_coverage": "最先端の研究開発施設で技術革新を推進"
+  }
+}

--- a/sakura-ken/data/transportation-logistics.json
+++ b/sakura-ken/data/transportation-logistics.json
@@ -1,0 +1,490 @@
+{
+  "railway_companies": [
+    {
+      "id": "RC001",
+      "name": "JR東日本桜花支社",
+      "type": "鉄道会社支社",
+      "company_name": "東日本旅客鉄道株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区鉄道ビル1-1",
+        "coordinates": {"lat": 35.7060, "lng": 139.8425}
+      },
+      "facility_info": {
+        "offices_floors": 8,
+        "control_center": true,
+        "training_center": true,
+        "maintenance_depot": true
+      },
+      "operations": {
+        "lines": ["東北新幹線", "桜花線", "桜川線"],
+        "stations_managed": 45,
+        "daily_passengers": 850000
+      },
+      "employees": {
+        "total": 2345,
+        "drivers": 456,
+        "conductors": 345,
+        "station_staff": 789,
+        "maintenance": 456,
+        "administrative": 299,
+        "management": [
+          {
+            "employee_id": "RC001-M001",
+            "name": "支社長田鉄道",
+            "position": "支社長",
+            "department": "支社統括部",
+            "hire_date": "2019-04-01",
+            "annual_salary": 15000000
+          },
+          {
+            "employee_id": "RC001-M002",
+            "name": "運輸田管理",
+            "position": "運輸部長",
+            "department": "運輸部",
+            "hire_date": "2020-04-01",
+            "annual_salary": 10000000
+          }
+        ]
+      }
+    },
+    {
+      "id": "RC002",
+      "name": "桜花電鉄本社",
+      "type": "私鉄本社",
+      "company_name": "桜花電鉄株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区私鉄通り2-2-2"
+      },
+      "operations": {
+        "lines": ["桜花本線", "空港線", "臨海線"],
+        "stations": 67,
+        "daily_passengers": 450000
+      },
+      "employees": {
+        "total": 1456,
+        "drivers": 234,
+        "conductors": 189,
+        "station_staff": 567,
+        "maintenance": 289,
+        "administrative": 177
+      }
+    }
+  ],
+  "bus_companies": [
+    {
+      "id": "BC001",
+      "name": "桜花市営バス営業所",
+      "type": "市営バス",
+      "location": {
+        "city": "桜花市",
+        "district": "交通地区",
+        "address": "桜花市交通地区バス基地1-1",
+        "area_m2": 35000
+      },
+      "facility_info": {
+        "bus_depots": 3,
+        "maintenance_bays": 20,
+        "fuel_stations": 5,
+        "washing_stations": 8
+      },
+      "fleet": {
+        "regular_buses": 234,
+        "articulated_buses": 12,
+        "electric_buses": 45,
+        "hybrid_buses": 89
+      },
+      "operations": {
+        "routes": 78,
+        "daily_passengers": 180000,
+        "stops": 1234
+      },
+      "employees": {
+        "total": 789,
+        "drivers": 456,
+        "mechanics": 123,
+        "dispatchers": 67,
+        "administrative": 143,
+        "management": [
+          {
+            "employee_id": "BC001-M001",
+            "name": "所長田運行",
+            "position": "営業所長",
+            "department": "運行管理部",
+            "hire_date": "2018-04-01",
+            "annual_salary": 8500000
+          }
+        ]
+      }
+    },
+    {
+      "id": "BC002",
+      "name": "桜花観光バス",
+      "type": "観光バス会社",
+      "location": {
+        "city": "桜花市",
+        "district": "観光地区",
+        "address": "桜花市観光地区バス通り2-2"
+      },
+      "fleet": {
+        "large_coaches": 45,
+        "medium_buses": 23,
+        "minibuses": 12
+      },
+      "employees": {
+        "total": 156,
+        "drivers": 89,
+        "guides": 23,
+        "mechanics": 20,
+        "administrative": 24
+      }
+    }
+  ],
+  "taxi_companies": [
+    {
+      "id": "TC001",
+      "name": "桜花タクシー本社",
+      "type": "タクシー会社",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区タクシー通り1-1"
+      },
+      "fleet": {
+        "regular_taxis": 234,
+        "premium_taxis": 23,
+        "wheelchair_accessible": 12,
+        "electric_taxis": 34
+      },
+      "employees": {
+        "total": 567,
+        "drivers": 456,
+        "dispatchers": 45,
+        "mechanics": 34,
+        "administrative": 32
+      },
+      "operations": {
+        "daily_rides": 4500,
+        "app_users": 89000
+      }
+    },
+    {
+      "id": "TC002",
+      "name": "さくら交通",
+      "type": "タクシー会社",
+      "location": {
+        "city": "桜川市",
+        "district": "中央地区",
+        "address": "桜川市中央地区交通通り2-2"
+      },
+      "fleet": {
+        "regular_taxis": 123,
+        "wheelchair_accessible": 8
+      },
+      "employees": {
+        "total": 234,
+        "drivers": 189,
+        "dispatchers": 23,
+        "administrative": 22
+      }
+    }
+  ],
+  "logistics_companies": [
+    {
+      "id": "LC001",
+      "name": "桜花物流センター",
+      "type": "物流センター",
+      "company_name": "桜花物流株式会社",
+      "location": {
+        "city": "桜花市",
+        "district": "物流地区",
+        "address": "桜花市物流地区配送センター1-1",
+        "area_m2": 85000
+      },
+      "facility_info": {
+        "warehouses": 5,
+        "total_storage_m2": 65000,
+        "loading_docks": 45,
+        "cold_storage": true,
+        "automated_sorting": true
+      },
+      "operations": {
+        "daily_packages": 125000,
+        "delivery_trucks": 156,
+        "service_area": "桜県全域"
+      },
+      "employees": {
+        "total": 1234,
+        "drivers": 456,
+        "warehouse_workers": 567,
+        "sorters": 123,
+        "administrative": 88,
+        "management": [
+          {
+            "employee_id": "LC001-M001",
+            "name": "センター長田物流",
+            "position": "センター長",
+            "department": "物流管理部",
+            "hire_date": "2017-04-01",
+            "annual_salary": 12000000
+          }
+        ]
+      }
+    },
+    {
+      "id": "LC002",
+      "name": "ヤマト運輸桜花主管支店",
+      "type": "宅配便営業所",
+      "company_name": "ヤマト運輸",
+      "location": {
+        "city": "桜花市",
+        "district": "配送地区",
+        "address": "桜花市配送地区宅配通り2-2"
+      },
+      "employees": {
+        "total": 345,
+        "drivers": 234,
+        "warehouse_workers": 67,
+        "administrative": 44
+      },
+      "operations": {
+        "daily_deliveries": 45000,
+        "delivery_vehicles": 89
+      }
+    },
+    {
+      "id": "LC003",
+      "name": "佐川急便桜花営業所",
+      "type": "宅配便営業所",
+      "company_name": "佐川急便",
+      "location": {
+        "city": "桜花市",
+        "district": "物流地区",
+        "address": "桜花市物流地区急便通り3-3"
+      },
+      "employees": {
+        "total": 289,
+        "drivers": 189,
+        "warehouse_workers": 67,
+        "administrative": 33
+      }
+    }
+  ],
+  "freight_companies": [
+    {
+      "id": "FC001",
+      "name": "桜花貨物ターミナル",
+      "type": "貨物駅",
+      "company_name": "JR貨物",
+      "location": {
+        "city": "桜花市",
+        "district": "貨物地区",
+        "address": "桜花市貨物地区ターミナル1-1",
+        "area_m2": 120000
+      },
+      "facility_info": {
+        "rail_tracks": 12,
+        "container_yard_m2": 80000,
+        "cranes": 8,
+        "warehouse_m2": 25000
+      },
+      "employees": {
+        "total": 234,
+        "operators": 123,
+        "crane_operators": 34,
+        "administrative": 77
+      },
+      "daily_containers": 1200
+    }
+  ],
+  "trucking_companies": [
+    {
+      "id": "TR001",
+      "name": "桜花運送本社",
+      "type": "運送会社",
+      "location": {
+        "city": "桜川市",
+        "district": "工業地区",
+        "address": "桜川市工業地区運送通り1-1"
+      },
+      "fleet": {
+        "large_trucks": 89,
+        "medium_trucks": 123,
+        "small_trucks": 156
+      },
+      "employees": {
+        "total": 456,
+        "drivers": 345,
+        "mechanics": 45,
+        "dispatchers": 34,
+        "administrative": 32
+      }
+    }
+  ],
+  "airports": [
+    {
+      "id": "AP001",
+      "name": "桜花国際空港",
+      "type": "国際空港",
+      "location": {
+        "city": "桜花市",
+        "district": "空港地区",
+        "address": "桜花市空港地区空港1-1",
+        "area_m2": 1500000
+      },
+      "facility_info": {
+        "terminals": 2,
+        "runways": 2,
+        "gates": 45,
+        "parking_spaces": 8000
+      },
+      "operations": {
+        "annual_passengers": 12000000,
+        "daily_flights": 234,
+        "cargo_tons_annually": 450000
+      },
+      "employees": {
+        "total": 3456,
+        "airport_operations": 789,
+        "security": 567,
+        "ground_staff": 890,
+        "air_traffic_control": 123,
+        "administrative": 1087
+      }
+    }
+  ],
+  "ports": [
+    {
+      "id": "PT001",
+      "name": "桜花港",
+      "type": "商業港",
+      "location": {
+        "city": "桜花市",
+        "district": "臨海地区",
+        "address": "桜花市臨海地区港湾1-1"
+      },
+      "facility_info": {
+        "berths": 15,
+        "container_terminals": 3,
+        "warehouses": 20,
+        "cranes": 25
+      },
+      "operations": {
+        "annual_containers_teu": 850000,
+        "annual_cargo_tons": 12000000
+      },
+      "employees": {
+        "total": 1567,
+        "dock_workers": 890,
+        "crane_operators": 234,
+        "customs": 123,
+        "administrative": 320
+      }
+    }
+  ],
+  "parking_facilities": [
+    {
+      "id": "PK001",
+      "name": "桜花駅前立体駐車場",
+      "type": "立体駐車場",
+      "operator": "桜花市",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区駐車場通り1-1"
+      },
+      "facility_info": {
+        "floors": 6,
+        "capacity": 1200,
+        "ev_charging": 50,
+        "disabled_spaces": 30
+      },
+      "employees": {
+        "total": 23,
+        "attendants": 15,
+        "security": 5,
+        "administrative": 3
+      }
+    }
+  ],
+  "car_rental": [
+    {
+      "id": "CR001",
+      "name": "トヨタレンタカー桜花駅前店",
+      "type": "レンタカー営業所",
+      "company_name": "トヨタレンタカー",
+      "location": {
+        "city": "桜花市",
+        "district": "駅前地区",
+        "address": "桜花市駅前地区レンタカー通り1-1"
+      },
+      "fleet": {
+        "compact_cars": 45,
+        "standard_cars": 34,
+        "luxury_cars": 12,
+        "vans": 23,
+        "trucks": 8
+      },
+      "employees": {
+        "total": 18,
+        "counter_staff": 8,
+        "drivers": 5,
+        "maintenance": 3,
+        "administrative": 2
+      }
+    }
+  ],
+  "gas_stations": [
+    {
+      "id": "GS001",
+      "name": "ENEOS桜花中央SS",
+      "type": "ガソリンスタンド",
+      "company_name": "ENEOS",
+      "location": {
+        "city": "桜花市",
+        "district": "中央区",
+        "address": "桜花市中央区給油通り1-1"
+      },
+      "facility_info": {
+        "fuel_pumps": 12,
+        "car_wash": true,
+        "convenience_store": true,
+        "ev_charging": 4
+      },
+      "employees": {
+        "total": 15,
+        "attendants": 10,
+        "shop_staff": 3,
+        "administrative": 2
+      }
+    }
+  ],
+  "bike_sharing": [
+    {
+      "id": "BS001",
+      "name": "桜花シェアサイクル",
+      "type": "自転車シェアリング",
+      "operator": "桜花市",
+      "stations": 123,
+      "bikes": 2345,
+      "employees": {
+        "total": 45,
+        "maintenance": 34,
+        "operations": 8,
+        "administrative": 3
+      }
+    }
+  ],
+  "summary": {
+    "total_transportation_employees": 18956,
+    "railway_employees": 3801,
+    "bus_taxi_employees": 1746,
+    "logistics_employees": 7234,
+    "airport_port_employees": 5023,
+    "other_transport": 1152,
+    "transportation_coverage": "総合的な交通・物流網で地域を支援"
+  }
+}


### PR DESCRIPTION
## 概要
桜県の200万人以上の住民に対応する包括的な雇用施設データを作成しました。

## 変更内容
- 医療、教育、行政、金融、交通、IT、専門サービス、メディア、ホテル、研究開発の10分野の施設データを追加
- 各施設に詳細な従業員情報、施設情報、サービス内容を含む
- 総計10万人以上の雇用を創出

Closes #57

Generated with [Claude Code](https://claude.ai/code)